### PR TITLE
Fix Link Monster ATK boost from Link Spell

### DIFF
--- a/official/c95515058.lua
+++ b/official/c95515058.lua
@@ -25,7 +25,7 @@ function s.initial_effect(c)
 end
 s.listed_series={0xfc}
 function s.atkval(e,c)
-	return c:GetLinkedGroupCount()*300
+	return c:GetLinkedGroup():FilterCount(Card.IsType,nil,TYPE_MONSTER)*300
 end
 function s.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()

--- a/unofficial/c511009652.lua
+++ b/unofficial/c511009652.lua
@@ -46,7 +46,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function s.atkval(e,c)
-	return c:GetLinkedGroupCount()*600
+	return c:GetLinkedGroup():FilterCount(Card.IsType,nil,TYPE_MONSTER)*600
 end
 function s.filter(c)
 	return c:IsType(TYPE_TRAP) and not c:IsPublic()

--- a/unofficial/c511600106.lua
+++ b/unofficial/c511600106.lua
@@ -30,7 +30,7 @@ function s.matfilter(c,lc,sumtype,tp)
 	return c:IsLevelAbove(3) and c:IsRace(RACE_CYBERSE,lc,sumtype,tp)
 end
 function s.atkval(e,c)
-	return c:GetLinkedGroupCount()*300
+	return c:GetLinkedGroup():FilterCount(Card.IsType,nil,TYPE_MONSTER)*300
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_LINK)


### PR DESCRIPTION
Monster having the effect "gain x ATK for each Monster it points to" would have gained x ATK from Link Spell like Judgment Arrow