### PR TITLE
Fix Bug for D.D. Sprite

### DIFF
--- a/official/c16638212.lua
+++ b/official/c16638212.lua
@@ -8,9 +8,14 @@ function s.initial_effect(c)
 	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
 	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(s.spcon)
 	e1:SetTarget(s.sptg)
 	e1:SetOperation(s.spop)
 	c:RegisterEffect(e1)
+end
+function s.spcon(e,c)
+    if c==nil then return true end
+    return Duel.IsExistingMatchingCard(aux.AND(Card.IsAbleToRemoveAsCost,Card.IsFaceup),tp,LOCATION_MZONE,0,1,nil)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,c)
 	local rg=Duel.GetMatchingGroup(Card.IsAbleToRemoveAsCost,tp,LOCATION_MZONE,0,nil):Filter(Card.IsFaceup,nil)


### PR DESCRIPTION
D.D. Sprite lists "Special Summon" as an option when you don't have a monster.

[https://cdn.discordapp.com/attachments/184324960842416129/697627557985517588/Screen_Shot_2020-04-08_at_10.01.52_PM.png](url)