### PR TITLE
Fix Toon Summoned Skull

### DIFF
--- a/official/c91842653.lua
+++ b/official/c91842653.lua
@@ -56,7 +56,7 @@ s.listed_names={15259703}
 function s.spcon(e,c)
 	if c==nil then return true end
 	return Duel.CheckReleaseGroup(c:GetControler(),aux.TRUE,1,false,1,true,c,c:GetControler(),nil,false,nil)
-		and Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsCode,15259703),tp,LOCATION_ONFIELD,0,1,nil)
+		and Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsCode,15259703),c:GetControler(),LOCATION_ONFIELD,0,1,nil)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,c)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)


### PR DESCRIPTION
tp parameter does not exist on funciton spcon, returning nil. This meant the condition check was only checking Toon World on the first player's field instead of their controller's