### PR TITLE
Fix Gouki Rising Scorpio

### DIFF
--- a/official/c60461077.lua
+++ b/official/c60461077.lua
@@ -28,10 +28,10 @@ s.listed_names={id}
 function s.cfilter(c)
 	return c:IsFacedown() or not c:IsSetCard(0xfc)
 end
-function s.ntcon(e,c,minc)
+function s.ntcon(e,c,minc,zone)
 	if c==nil then return true end
 	local tp=c:GetControler()
-	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+	return minc==0 and c:GetLevel()>4 and Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_TOFIELD,zone)>0
 		and (Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0 or not Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil))
 end
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
It was not checking for linked zones on its special normal summon condition