### PR TITLE
"/Assault Mode" monster updates

### DIFF
--- a/official/c14553285.lua
+++ b/official/c14553285.lua
@@ -49,7 +49,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 s.counter_place_list={COUNTER_SPELL}
-s.listed_names={31924889}
+s.listed_names={CARD_ASSAULT_MODE,31924889}
 s.assault_mode=31924889
 function s.addct(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/official/c1764972.lua
+++ b/official/c1764972.lua
@@ -32,7 +32,7 @@ function s.initial_effect(c)
 	e3:SetOperation(s.spop2)
 	c:RegisterEffect(e3)
 end
-s.listed_names={6021033}
+s.listed_names={CARD_ASSAULT_MODE,6021033}
 s.assault_mode=6021033
 function s.filter1(c,e,tp)
 	return c:IsRace(RACE_ZOMBIE) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/official/c37169670.lua
+++ b/official/c37169670.lua
@@ -1,4 +1,5 @@
 --ハイパーサイコガンナー／バスター
+--Hyper Psychic Blaster/Assault Mode
 local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
@@ -9,7 +10,7 @@ function s.initial_effect(c)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e1:SetValue(aux.FALSE)
 	c:RegisterEffect(e1)
-	--damage&recover
+	--damage & recover
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_DAMAGE+CATEGORY_RECOVER)
@@ -30,7 +31,7 @@ function s.initial_effect(c)
 	e3:SetOperation(s.spop)
 	c:RegisterEffect(e3)
 end
-s.listed_names={95526884}
+s.listed_names={CARD_ASSAULT_MODE,95526884}
 s.assault_mode=95526884
 function s.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetAttackTarget()~=nil end

--- a/official/c38898779.lua
+++ b/official/c38898779.lua
@@ -1,4 +1,5 @@
 --ギガンテック・ファイター/バスター
+--Colossal Fighter/Assault Mode
 local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
@@ -38,7 +39,7 @@ function s.initial_effect(c)
 	e4:SetOperation(s.spop)
 	c:RegisterEffect(e4)
 end
-s.listed_names={23693634}
+s.listed_names={CARD_ASSAULT_MODE,23693634}
 s.assault_mode=23693634
 function s.tgfilter(c)
 	return c:IsRace(RACE_WARRIOR) and c:IsAbleToGrave()

--- a/official/c61257789.lua
+++ b/official/c61257789.lua
@@ -46,7 +46,7 @@ function s.initial_effect(c)
 	e4:SetOperation(s.spop)
 	c:RegisterEffect(e4)
 end
-s.listed_names={44508094,80280737}
+s.listed_names={CARD_ASSAULT_MODE,44508094}
 s.assault_mode=44508094
 function s.negcon(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) and Duel.IsChainNegatable(ev)

--- a/unofficial/c511002518.lua
+++ b/unofficial/c511002518.lua
@@ -34,7 +34,7 @@ function s.initial_effect(c)
 	e3:SetOperation(s.spop)
 	c:RegisterEffect(e3)
 end
-s.listed_names={70902743}
+s.listed_names={CARD_ASSAULT_MODE,70902743}
 s.assault_mode=70902743
 function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetAttacker()==e:GetHandler()


### PR DESCRIPTION
The following are now considered to be listing "Assault Mode Activate" in their text:
- Hyper Psychic Blaster/Assault Mode
- Colossal Fighter/Assault Mode
- Arcanite Magician/Assault Mode
- Doomkaiser Dragon/Assault Mode
- Red Dragon Archfiend/Assault Mode (Anime)

"Stardust Dragon/Assault Mode" was already doing that, but it was updated to use the appropriate constant for it.