### PR TITLE
Added "Light And Darkness Dragon (Manga)

### DIFF
--- a/unofficial/c511231004.lua
+++ b/unofficial/c511231004.lua
@@ -1,0 +1,52 @@
+--光と闇の竜
+--Light And Darkness Dragon (Manga)
+--By Astral
+local s,id=GetID()
+function s.initial_effect(c)
+	--Negate
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,2))
+	e3:SetCategory(CATEGORY_NEGATE)
+	e3:SetType(EFFECT_TYPE_QUICK_F)
+	e3:SetCode(EVENT_CHAINING)
+	e3:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCondition(s.codisable)
+	e3:SetTarget(s.tgdisable)
+	e3:SetOperation(s.opdisable)
+	c:RegisterEffect(e3)
+end
+function s.codisable(e,tp,eg,ep,ev,re,r,rp)
+	return (re:IsHasType(EFFECT_TYPE_ACTIVATE) or re:IsActiveType(TYPE_MONSTER))
+		and not e:GetHandler():IsStatus(STATUS_CHAINING)
+end
+function s.tgdisable(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:GetFlagEffect(id)==0 end
+	if c:IsHasEffect(EFFECT_REVERSE_UPDATE) then
+		c:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+end
+function s.opdisable(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsFaceup() or c:GetDefense()<500 or c:GetAttack()< 500 or not c:IsRelateToEffect(e) or Duel.GetCurrentChain()~=ev+1 or c:IsStatus(STATUS_BATTLE_DESTROYED) then
+		return
+	end
+	if Duel.NegateActivation(ev) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_COPY_INHERIT)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD_DISABLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(-500)
+		c:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetProperty(EFFECT_FLAG_COPY_INHERIT)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD_DISABLE)
+		e2:SetCode(EFFECT_UPDATE_DEFENSE)
+		e2:SetValue(-500)
+		c:RegisterEffect(e2)
+	end
+end


### PR DESCRIPTION
Previously spoke with a staff member about this (larry126)
Added Light And Darkness Dragon (manga), unlike the TCG version it can be special summoned, it has no effect when sent to the graveyard and it is not considered a DARK monster.

Attached here are the CDB containing the card, and the Manga version of the card's artwork.
[LADD MANGA CDB.zip](https://github.com/ProjectIgnis/CardScripts/files/4578636/LADD.MANGA.CDB.zip)
![511231004](https://user-images.githubusercontent.com/61868752/81029644-13f7f300-8e86-11ea-9d86-d683cd6a3233.jpg)
