### PR TITLE
Fix cards with EFFECT_OVERLAY_REMOVE_REPLACE

### DIFF
--- a/official/c13032689.lua
+++ b/official/c13032689.lua
@@ -1,4 +1,5 @@
 --エクシーズ・ユニット
+--Xyz Unit
 local s,id=GetID()
 function s.initial_effect(c)
 	aux.AddEquipProcedure(c,nil,aux.FilterBoolFunction(Card.IsType,TYPE_XYZ))
@@ -26,11 +27,5 @@ function s.rcon(e,tp,eg,ep,ev,re,r,rp)
 		and ep==e:GetOwnerPlayer() and e:GetHandler():GetEquipTarget()==re:GetHandler() and re:GetHandler():GetOverlayCount()>=ev-1
 end
 function s.rop(e,tp,eg,ep,ev,re,r,rp)
-	local ct=(ev&0xffff)
-	if ct==1 then
-		Duel.SendtoGrave(e:GetHandler(),REASON_COST)
-	else
-		Duel.SendtoGrave(e:GetHandler(),REASON_COST)
-		re:GetHandler():RemoveOverlayCard(tp,ct-1,ct-1,REASON_COST)
-	end
+	return Duel.SendtoGrave(e:GetHandler(),REASON_COST)
 end

--- a/official/c55067058.lua
+++ b/official/c55067058.lua
@@ -23,7 +23,5 @@ function s.rcon(e,tp,eg,ep,ev,re,r,rp)
 		and ep==e:GetOwnerPlayer() and re:GetHandler():GetOverlayCount()>=ev-1
 end
 function s.rop(e,tp,eg,ep,ev,re,r,rp)
-	if e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_EFFECT) then
-		return true
-	end
+	return e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_EFFECT) 
 end

--- a/official/c55067058.lua
+++ b/official/c55067058.lua
@@ -1,4 +1,5 @@
 --No.19 フリーザードン
+--Number 19: Freezadon
 local s,id=GetID()
 function s.initial_effect(c)
 	--xyz summon
@@ -22,11 +23,7 @@ function s.rcon(e,tp,eg,ep,ev,re,r,rp)
 		and ep==e:GetOwnerPlayer() and re:GetHandler():GetOverlayCount()>=ev-1
 end
 function s.rop(e,tp,eg,ep,ev,re,r,rp)
-	local ct=(ev&0xffff)
-	if ct==1 then
-		e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_EFFECT)
-	else
-		e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_EFFECT)
-		re:GetHandler():RemoveOverlayCard(tp,ct-1,ct-1,REASON_COST)
+	if e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_EFFECT) then
+		return true
 	end
 end

--- a/official/c83880087.lua
+++ b/official/c83880087.lua
@@ -1,4 +1,5 @@
 --ムーンバリア
+--Light Wing Shield
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -73,5 +74,5 @@ function s.rcon(e,tp,eg,ep,ev,re,r,rp)
 		and ep==e:GetOwnerPlayer() and ev==1
 end
 function s.rop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
+	return Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_COST)
 end

--- a/official/c94807487.lua
+++ b/official/c94807487.lua
@@ -1,4 +1,5 @@
 --ホープ剣スラッシュ
+--Rising Sun Slash
 local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableCounterPermit(0x31)
@@ -47,9 +48,5 @@ function s.rcon(e,tp,eg,ep,ev,re,r,rp)
 		and ep==e:GetOwnerPlayer() and e:GetHandler():GetEquipTarget()==re:GetHandler() and re:GetHandler():GetOverlayCount()>=ev-1
 end
 function s.rop(e,tp,eg,ep,ev,re,r,rp)
-	local ct=(ev&0xffff)
-	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
-	if ct>1 then
-		re:GetHandler():RemoveOverlayCard(tp,ct-1,ct-1,REASON_COST)
-	end
+	return Duel.SendtoGrave(e:GetHandler(),REASON_COST)
 end

--- a/official/c98918572.lua
+++ b/official/c98918572.lua
@@ -1,4 +1,5 @@
 --十二獣の相剋
+--Zoodiac Gathering
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -43,6 +44,7 @@ function s.rop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	local tg=Duel.SelectMatchingCard(tp,s.rfilter,tp,LOCATION_MZONE,0,1,1,rc,ct)
 	tg:GetFirst():RemoveOverlayCard(tp,ct,ct,REASON_COST)
+	return ct
 end
 function s.xyzfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_XYZ) and c:IsSetCard(0xf1)


### PR DESCRIPTION
Concerned Cards:
- Xyz Unit
- Number 19: Freezadon
- Light Wing Shield
- Rising Sun Slash
- Zoodiac Gathering

Issue: Previously, the number of material used instead was hardcoded to 1, now it take the return value of the operation function