### PR TITLE
Small fix for "Gagaga Mirror Slash"

### DIFF
--- a/unofficial/c511000673.lua
+++ b/unofficial/c511000673.lua
@@ -55,7 +55,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
 		e3:SetRange(LOCATION_MZONE)
 		e3:SetOperation(s.atkop)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e3:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e3)
 	end
 end


### PR DESCRIPTION
Fixed a typo in line 58.
SetReset should apply to e3 not e1.
I don't know why github wants to delete the whole file again.
I didn't change anything with respect to the indentation.