### PR TITLE
small fix millennium eye

### DIFF
--- a/skill/c300201009.lua
+++ b/skill/c300201009.lua
@@ -23,6 +23,8 @@ function s.flipop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.ShuffleDeck(g:GetFirst():GetControler())
 			Duel.BreakEffect()
 			Duel.Draw(g:GetFirst():GetControler(),#g,REASON_EFFECT)
+		else
+			Duel.ShuffleHand(g:GetFirst():GetControler())
 		end
 	end
 end


### PR DESCRIPTION
The opponent's hand will shuffle automatically if the player said no to shuffle the opponent's hand into his deck.
It's because opponent's original hand is still visible after the turn which the skill card was activate as long as the opponent doesn't shuffle his hand manually.
