### PR TITLE
Fix "Ledger of Legerdemain"

### DIFF
--- a/official/c56256517.lua
+++ b/official/c56256517.lua
@@ -27,7 +27,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	g:KeepAlive()
 	local c=e:GetHandler()
 	c:SetTurnCounter(0)
-	local fid=c:GetFieldID()
+	local fid=Duel.GetTurnCount()
 	for tc in aux.Next(g) do
 		tc:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD,0,1,fid)
 	end
@@ -51,13 +51,11 @@ function s.thfilter(c,fid)
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local ct=c:GetTurnCounter()
-	ct=ct+1
-	if ct==3 then
+	local ct=e:GetLabel()
+	if ct+6==Duel.GetTurnCount() then
 		local g=e:GetLabelObject():Filter(s.thfilter,nil,e:GetLabel())
 		if g and #g==3 then
 			Duel.SendtoHand(g,nil,REASON_EFFECT)
 		end
-	else c:SetTurnCounter(ct) end
+	end
 end
-


### PR DESCRIPTION
Use the TurnCount as Turn Counter as activating the same card copy recovered from the GY would mess with the Card's Turn Counter