### PR TITLE
Setcode Condition Rule update

### DIFF
--- a/official/c11067666.lua
+++ b/official/c11067666.lua
@@ -2,7 +2,7 @@
 --White Wing Magician
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x2017)
+	Duel.AddSetcodesRule(c,0x2017)
 	Pendulum.AddProcedure(c)
 	--Negate
 	local e1=Effect.CreateEffect(c)

--- a/official/c17775525.lua
+++ b/official/c17775525.lua
@@ -2,7 +2,7 @@
 --Superheavy Samurai Steam Fiend Tetsudo'o
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--synchro summon
 	Synchro.AddProcedure(c,aux.FilterBoolFunctionEx(Card.IsSetCard,0x9a),1,1,Synchro.NonTunerEx(Card.IsSetCard,0x9a),2,99)
 	c:EnableReviveLimit()

--- a/official/c21521304.lua
+++ b/official/c21521304.lua
@@ -2,7 +2,7 @@
 --Number 39: Utopia Beyond
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x107f)
+	Duel.AddSetcodesRule(c,0x107f)
 	--xyz summon
 	Xyz.AddProcedure(c,nil,6,2)
 	c:EnableReviveLimit()

--- a/official/c23204029.lua
+++ b/official/c23204029.lua
@@ -2,7 +2,7 @@
 --Contrast HERO Chaos
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x3008)
+	Duel.AddSetcodesRule(c,0x3008)
 	--fusion material
 	c:EnableReviveLimit()
 	Fusion.AddProcMixN(c,true,true,aux.FilterBoolFunctionEx(Card.IsSetCard,0xa008),2)

--- a/official/c25800447.lua
+++ b/official/c25800447.lua
@@ -2,7 +2,7 @@
 --Fusion of Fire
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x119)
+	Duel.AddSetcodesRule(c,0x119)
 	--Activate
 	local e1=Fusion.CreateSummonEff(c,aux.FilterBoolFunction(Card.IsSetCard,0x119),nil,s.fextra)
 	e1:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)

--- a/official/c26973555.lua
+++ b/official/c26973555.lua
@@ -3,7 +3,7 @@
 --Scripted by AlphaKretin
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x207f)
+	Duel.AddSetcodesRule(c,0x207f)
 	--xyz summon
 	c:EnableReviveLimit()
 	Xyz.AddProcedure(c,s.xyzfilter,nil,3,aux.FilterFaceupFunction(Card.IsCode,65305468),aux.Stringid(id,0),nil,nil,false,s.xyzcheck)

--- a/official/c30674956.lua
+++ b/official/c30674956.lua
@@ -3,7 +3,7 @@
 --Scripted by ahtelel
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x10c0)
+	Duel.AddSetcodesRule(c,0x10c0)
 	--Link summon
 	Link.AddProcedure(c,nil,2,2,s.lcheck)
 	c:EnableReviveLimit()

--- a/official/c34130561.lua
+++ b/official/c34130561.lua
@@ -3,7 +3,7 @@
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0xbd)
+	Duel.AddSetcodesRule(c,0xbd)
 	--normal summon
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,0))

--- a/official/c34566435.lua
+++ b/official/c34566435.lua
@@ -2,7 +2,7 @@
 --Edge Imp Frightfuloid
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0xad)
+	Duel.AddSetcodesRule(c,0xad)
 	--atk
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))

--- a/official/c36953371.lua
+++ b/official/c36953371.lua
@@ -2,7 +2,7 @@
 --Superheavy Samurai Ogre Shutendoji
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--synchro summon
 	Synchro.AddProcedure(c,aux.FilterBoolFunctionEx(Card.IsRace,RACE_MACHINE),1,1,Synchro.NonTunerEx(Card.IsSetCard,0x9a),1,99)
 	c:EnableReviveLimit()

--- a/official/c39299733.lua
+++ b/official/c39299733.lua
@@ -3,7 +3,7 @@
 --scripted by AlphaKretin
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x122)
+	Duel.AddSetcodesRule(c,0x122)
 	aux.AddUnionProcedure(c,aux.FilterBoolFunction(Card.IsRace,RACE_FAIRY),false)
 	--Direct attack
 	local e1=Effect.CreateEffect(c)

--- a/official/c40945356.lua
+++ b/official/c40945356.lua
@@ -2,7 +2,7 @@
 --Twilight Ninja Nichirin, the Chunin
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x2b)
+	Duel.AddSetcodesRule(c,0x2b)
 	--negate
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))

--- a/official/c42880485.lua
+++ b/official/c42880485.lua
@@ -2,7 +2,7 @@
 --Superheavy Samurai General Jade
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--pendulum summon
 	Pendulum.AddProcedure(c)
 	--splimit

--- a/official/c45467446.lua
+++ b/official/c45467446.lua
@@ -2,7 +2,7 @@
 --Dragon Spirit of White
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0xdd)
+	Duel.AddSetcodesRule(c,0xdd)
 	--Normal monster
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/official/c45531624.lua
+++ b/official/c45531624.lua
@@ -2,7 +2,7 @@
 --Celtic Guard of Noble Arms
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0xe4)
+	Duel.AddSetcodesRule(c,0xe4)
 	--cannot attack
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)

--- a/official/c46898368.lua
+++ b/official/c46898368.lua
@@ -3,7 +3,7 @@
 --Scripted by Larry126
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x119)
+	Duel.AddSetcodesRule(c,0x119)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DRAW)

--- a/official/c48461764.lua
+++ b/official/c48461764.lua
@@ -2,7 +2,7 @@
 --Purple Poison Magician
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x1046)
+	Duel.AddSetcodesRule(c,0x1046)
 	Pendulum.AddProcedure(c)
 	--Increase ATK
 	local e1=Effect.CreateEffect(c)

--- a/official/c48815792.lua
+++ b/official/c48815792.lua
@@ -3,7 +3,7 @@
 --Scripted by ahtelel
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x10c0)
+	Duel.AddSetcodesRule(c,0x10c0)
 	--link summon
 	Link.AddProcedure(c,nil,2,2,s.lcheck)
 	c:EnableReviveLimit()

--- a/official/c494922.lua
+++ b/official/c494922.lua
@@ -2,7 +2,7 @@
 --Superheavy Samurai Warlord Susanowo
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--synchro summon
 	Synchro.AddProcedure(c,aux.FilterBoolFunctionEx(Card.IsRace,RACE_MACHINE),1,1,Synchro.NonTuner(Card.IsSetCard,0x9a),1,99)
 	c:EnableReviveLimit()

--- a/official/c49684352.lua
+++ b/official/c49684352.lua
@@ -2,7 +2,7 @@
 --Double Iris Magician
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x10f2)
+	Duel.AddSetcodesRule(c,0x10f2)
 	Pendulum.AddProcedure(c)
 	--Double damage
 	local e1=Effect.CreateEffect(c)

--- a/official/c50065971.lua
+++ b/official/c50065971.lua
@@ -2,7 +2,7 @@
 --Superheavy Samurai Stealth Ninja
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	c:EnableReviveLimit()
 	Synchro.AddProcedure(c,aux.FilterBoolFunctionEx(Card.IsRace,RACE_MACHINE),1,1,Synchro.NonTunerEx(Card.IsRace,RACE_MACHINE),1,99)
 	--defense attack

--- a/official/c54423935.lua
+++ b/official/c54423935.lua
@@ -2,7 +2,7 @@
 --Raidraptor Replica
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0xba)
+	Duel.AddSetcodesRule(c,0xba)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)

--- a/official/c66750703.lua
+++ b/official/c66750703.lua
@@ -3,7 +3,7 @@
 --Scripted by ahtelel
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x7c)
+	Duel.AddSetcodesRule(c,0x7c)
 	c:EnableCounterPermit(0x201)
 	--activate
 	local e1=Effect.CreateEffect(c)

--- a/official/c66947913.lua
+++ b/official/c66947913.lua
@@ -3,7 +3,7 @@
 --scripted by Naim, based off of Larry126's Anime version
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x119)
+	Duel.AddSetcodesRule(c,0x119)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)

--- a/official/c73309655.lua
+++ b/official/c73309655.lua
@@ -2,7 +2,7 @@
 --Eria the Water Charmer, Gentle
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x10c0)
+	Duel.AddSetcodesRule(c,0x10c0)
 	--Link summon
 	Link.AddProcedure(c,nil,2,2,s.lcheck)
 	c:EnableReviveLimit()

--- a/official/c74839123.lua
+++ b/official/c74839123.lua
@@ -2,7 +2,7 @@
 --Frightfur Sanctuary
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0xad)
+	Duel.AddSetcodesRule(c,0xad)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)

--- a/official/c75672051.lua
+++ b/official/c75672051.lua
@@ -2,7 +2,7 @@
 --Black Fang Magician
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x2073)
+	Duel.AddSetcodesRule(c,0x2073)
 	Pendulum.AddProcedure(c)
 	--Halve ATK
 	local e1=Effect.CreateEffect(c)

--- a/official/c75988594.lua
+++ b/official/c75988594.lua
@@ -2,7 +2,7 @@
 --Superheavy Samurai Swordmaster Musashi
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--synchro summon
 	Synchro.AddProcedure(c,nil,1,1,Synchro.NonTuner(nil),1,99)
 	c:EnableReviveLimit()

--- a/official/c76471944.lua
+++ b/official/c76471944.lua
@@ -2,7 +2,7 @@
 --Superheavy Samurai Ninja Sarutobi
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--synchro summon
 	Synchro.AddProcedure(c,aux.FilterBoolFunctionEx(Card.IsRace,RACE_MACHINE),1,1,Synchro.NonTunerEx(Card.IsSetCard,0x9a),1,99)
 	c:EnableReviveLimit()

--- a/official/c78274190.lua
+++ b/official/c78274190.lua
@@ -2,7 +2,7 @@
 --Superheavy Samurai General Coral
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--pendulum summon
 	Pendulum.AddProcedure(c)
 	--scale

--- a/official/c8512558.lua
+++ b/official/c8512558.lua
@@ -3,7 +3,7 @@
 --Scripted by Logical Nonsense and AlphaKretin, revised handling of archetype check by edo9300
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x54,0x59,0x82,0x8f)
+	Duel.AddSetcodesRule(c,0x54,0x59,0x82,0x8f)
 	--Special summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))

--- a/official/c85528209.lua
+++ b/official/c85528209.lua
@@ -2,7 +2,7 @@
 --Superheavy Samurai Beast Kyubi
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--synchro summon
 	Synchro.AddProcedure(c,nil,1,1,Synchro.NonTunerEx(Card.IsSetCard,0x9a),1,99)
 	c:EnableReviveLimit()

--- a/official/c86395581.lua
+++ b/official/c86395581.lua
@@ -4,7 +4,7 @@
 --Substitute ID
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0xbf)
+	Duel.AddSetcodesRule(c,0xbf)
 	--Discard this + WIND monster; add WIND monster with <= 1500 DEF, locked into WIND effects
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,0))

--- a/official/c92345028.lua
+++ b/official/c92345028.lua
@@ -3,7 +3,7 @@
 --anime version scripted by pyrQ, changes in OCG version by Naim
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x119)
+	Duel.AddSetcodesRule(c,0x119)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)

--- a/official/c97661969.lua
+++ b/official/c97661969.lua
@@ -3,7 +3,7 @@
 --Scripted by ahtelel
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x10c0)
+	Duel.AddSetcodesRule(c,0x10c0)
 	--Link summon
 	Link.AddProcedure(c,nil,2,2,s.lcheck)
 	c:EnableReviveLimit()

--- a/pre-release/c101102001.lua
+++ b/pre-release/c101102001.lua
@@ -2,7 +2,7 @@
 --Raiders' Wing
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x10db,0xba)
+	Duel.AddSetcodesRule(c,0x10db,0xba)
 	--Special summon this card
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(id,0))

--- a/pre-release/c101102061.lua
+++ b/pre-release/c101102061.lua
@@ -3,7 +3,7 @@
 --scripted by Naim
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x107)
+	Duel.AddSetcodesRule(c,0x107)
 	--Search on activation
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))

--- a/pre-release/c101102062.lua
+++ b/pre-release/c101102062.lua
@@ -3,7 +3,7 @@
 --scripted by Naim
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x107)
+	Duel.AddSetcodesRule(c,0x107)
 	--activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))

--- a/pre-release/c101102068.lua
+++ b/pre-release/c101102068.lua
@@ -3,7 +3,7 @@
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x10db,0xba)
+	Duel.AddSetcodesRule(c,0x10db,0xba)
 	--Activate
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_ACTIVATE)

--- a/pre-release/c101102076.lua
+++ b/pre-release/c101102076.lua
@@ -3,7 +3,7 @@
 --scripted by Naim
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x107)
+	Duel.AddSetcodesRule(c,0x107)
 	--Special Summon when destroying by battle
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))

--- a/unofficial/c100000150.lua
+++ b/unofficial/c100000150.lua
@@ -1,7 +1,7 @@
 --ワンハンドレッド·アイ·ドラゴン
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,8)

--- a/unofficial/c100000151.lua
+++ b/unofficial/c100000151.lua
@@ -1,7 +1,7 @@
 --ダーク・フラット・トップ
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,8)

--- a/unofficial/c100000152.lua
+++ b/unofficial/c100000152.lua
@@ -1,7 +1,7 @@
 --猿魔王 ゼーマン
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,7)

--- a/unofficial/c100000153.lua
+++ b/unofficial/c100000153.lua
@@ -1,7 +1,7 @@
 --月影龍 クイラ
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,6)

--- a/unofficial/c100000154.lua
+++ b/unofficial/c100000154.lua
@@ -1,7 +1,7 @@
 --地底のアラクネー
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,6)

--- a/unofficial/c100000155.lua
+++ b/unofficial/c100000155.lua
@@ -3,7 +3,7 @@
 local s,id,alias=GetID()
 function s.initial_effect(c)
 	alias=c:Alias()
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,5)

--- a/unofficial/c100000156.lua
+++ b/unofficial/c100000156.lua
@@ -1,7 +1,7 @@
 --漆黒のズムウォル
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,4)

--- a/unofficial/c100000482.lua
+++ b/unofficial/c100000482.lua
@@ -1,7 +1,7 @@
 --天輪の葬送士
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x211)
+	Duel.AddSetcodesRule(c,0x211)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)

--- a/unofficial/c511000817.lua
+++ b/unofficial/c511000817.lua
@@ -3,7 +3,7 @@
 --updated by Larry126
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,0)

--- a/unofficial/c511001952.lua
+++ b/unofficial/c511001952.lua
@@ -1,7 +1,7 @@
 --Phantasmal Lord Ultimitl Bishbaalkin (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--level 0
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,0)
 	c:SetStatus(STATUS_NO_LEVEL,true)

--- a/unofficial/c511005042.lua
+++ b/unofficial/c511005042.lua
@@ -2,7 +2,7 @@
 --original script by Shad3
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x21b)
+	Duel.AddSetcodesRule(c,0x21b)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SUMMON_PROC)

--- a/unofficial/c511009065.lua
+++ b/unofficial/c511009065.lua
@@ -1,7 +1,7 @@
 --Superheavy Samurai Ninja Sarutobi
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--synchro summon
 	Synchro.AddProcedure(c,aux.FilterBoolFunctionEx(Card.IsRace,RACE_MACHINE),1,1,Synchro.NonTunerEx(Card.IsSetCard,0x9a),1,99)
 	c:EnableReviveLimit()

--- a/unofficial/c511009553.lua
+++ b/unofficial/c511009553.lua
@@ -1,7 +1,7 @@
 --Superheavy Samurai Steam Fiend Tetsudo'o
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x9a)
+	Duel.AddSetcodesRule(c,0x9a)
 	--synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddProcedure(c,nil,1,1,Synchro.NonTuner(Card.IsSetCard,0x9a),1,99)

--- a/unofficial/c511600137.lua
+++ b/unofficial/c511600137.lua
@@ -3,7 +3,7 @@
 --scripted by Larry126
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,6)

--- a/unofficial/c511600138.lua
+++ b/unofficial/c511600138.lua
@@ -3,7 +3,7 @@
 --scripted by Larry126
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,4)

--- a/unofficial/c513000004.lua
+++ b/unofficial/c513000004.lua
@@ -2,7 +2,7 @@
 --Hundred Eyes Dragon (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,8)

--- a/unofficial/c513000186.lua
+++ b/unofficial/c513000186.lua
@@ -2,7 +2,7 @@
 --月影龍 クイラ
 local s,id=GetID()
 function s.initial_effect(c)
-	c:AddSetcodesRule(0x601)
+	Duel.AddSetcodesRule(c,0x601)
 	--dark synchro summon
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,6)

--- a/utility.lua
+++ b/utility.lua
@@ -5,23 +5,22 @@ function GetID()
 	return self_table,self_code
 end
 
-local function setcodecondition(e)
-	return e:GetHandler():IsCode(e:GetHandler():GetOriginalCodeRule())
-end
-
-function Card.AddSetcodesRule(c,...)
-	local t={}
-	for _,setcode in pairs({...}) do
-		local e=Effect.CreateEffect(c)
-		e:SetType(EFFECT_TYPE_SINGLE)
-		e:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-		e:SetCode(EFFECT_ADD_SETCODE)
-		e:SetValue(setcode)
-		e:SetCondition(setcodecondition)
-		c:RegisterEffect(e)
-		table.insert(t,e)
-	end
-	return t
+function Duel.AddSetcodesRule(c,...)
+	 if usedsets[c:GetCode()] then return end
+    usedsets[c:GetCode()]=true
+    local t={}
+    for _,setcode in pairs({...}) do
+        local e=Effect.CreateEffect(c)
+        e:SetType(EFFECT_TYPE_FIELD)
+        e:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_SET_AVAILABLE)
+        e:SetTargetRange(0xff,0xff)
+        e:SetCode(EFFECT_ADD_SETCODE)
+        e:SetValue(setcode)
+        e:SetTarget(aux.TargetBoolFunction(Card.IsCode,c:GetCode()))
+        Duel.RegisterEffect(e,1)
+        table.insert(t,e)
+    end
+    return t
 end
 
 function Duel.LoadCardScript(code)

--- a/utility.lua
+++ b/utility.lua
@@ -4,7 +4,7 @@ aux=Auxiliary
 function GetID()
 	return self_table,self_code
 end
-
+local usedsets={}
 function Duel.AddSetcodesRule(c,...)
 	 if usedsets[c:GetCode()] then return end
     usedsets[c:GetCode()]=true


### PR DESCRIPTION
Updated the utility so monsters that copy the name also get the archetype condition (for exemple, an The Tyrant Neptune summoned using an Wynn the Wind Medium and that copied Wynn name should be treated as a "Charmer" monster)