### PR TITLE
Fix "Destiny HERO - Dreamer (Anime)"

### DIFF
--- a/unofficial/c511004407.lua
+++ b/unofficial/c511004407.lua
@@ -73,7 +73,7 @@ function s.op(e,tp,eg,ev,ep,re,r,rp)
 		e3:SetType(EFFECT_TYPE_SINGLE)
 		e3:SetCode(EFFECT_EXTRA_ATTACK)
 		e3:SetValue(1)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e3:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e3)
 	end
 end


### PR DESCRIPTION
Reset not tagged to correct effect. Allowed multiple attacks even after being removed from field 