### PR TITLE
Small Fix for "Supreme King Dragon Starving Venom"

### DIFF
--- a/official/c43387895.lua
+++ b/official/c43387895.lua
@@ -48,7 +48,7 @@ function s.copyop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if tc and c:IsRelateToEffect(e) and c:IsFaceup() and tc:IsRelateToEffect(e) and (tc:IsFaceup() or tc:IsLocation(LOCATION_GRAVE)) then
-		local code=tc:GetOriginalCodeRule()
+		local code=tc:GetOriginalCode()
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)


### PR DESCRIPTION
Fixed a false interaction when copying the name and effects of anime cards with a duplicate name but a different effect from an official card. As it was before, the official card's effects were copied, even though the anime version was targeted.