### PR TITLE
Fix for "Sunavalon Bloom"

### DIFF
--- a/unofficial/c511009700.lua
+++ b/unofficial/c511009700.lua
@@ -61,7 +61,7 @@ function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsStatus(STATUS_DESTROY_CONFIRMED) then return false end
 	local tc=c:GetFirstCardTarget()
-	return tc and eg:IsContains(tc) and tc:IsReason(REASON_DESTROY)
+	return tc and eg:IsContains(tc)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Destroy(e:GetHandler(),REASON_EFFECT)


### PR DESCRIPTION
Card wouldn't destroy itself if the monster was Tributed or sent to the GY.