### PR TITLE
Fix for "Soprano the Melodious Songstress (Anime)"

### DIFF
--- a/unofficial/c511002485.lua
+++ b/unofficial/c511002485.lua
@@ -4,7 +4,7 @@
 local s,id=GetID()
 function s.initial_effect(c)
 	--perform a fusion summon
-	local params = {nil,Fusion.CheckWithHandler(nil,nil,nil,Fusion.ForcedHandler)}
+	local params = {nil,nil,nil,nil,Fusion.ForcedHandler}
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
 	e1:SetType(EFFECT_TYPE_IGNITION)


### PR DESCRIPTION
Fixed monster being unable to activate Fusion Summon effect even with valid targets in Extra Deck.