### PR TITLE
Add "Performapal Dag Daggerman (Anime)"

### DIFF
--- a/unofficial/c199900001.lua
+++ b/unofficial/c199900001.lua
@@ -1,36 +1,65 @@
---星因士 プロキオン
---Performapal Dag Daggerman
+--EMダグ・ダガーマン
 local s,id=GetID()
 function s.initial_effect(c)
-	--handes
+	--pendulum summon
+	Pendulum.AddProcedure(c)
+	--to hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
-	e1:SetCategory(CATEGORY_HANDES+CATEGORY_DRAW)
+	e1:SetCategory(CATEGORY_TOHAND)
 	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_MZONE)
-	e2:SetCost(s.dcost)
-	e1:SetTarget(s.target)
-	e1:SetOperation(s.operation)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCountLimit(1)
+	e1:SetTarget(s.thtg)
+	e1:SetOperation(s.thop)
 	c:RegisterEffect(e1)
+	--draw
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetCategory(CATEGORY_DRAW)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCost(s.drcost)
+	e2:SetTarget(s.drtg)
+	e2:SetOperation(s.drop)
+	c:RegisterEffect(e2)
 end
 s.listed_series={0x9f}
-function s.filter(c,tp)
+function s.thfilter(c)
+	return c:IsSetCard(0x9f) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and s.thfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(s.thfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,s.thfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function s.thop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+	end
+end
+function s.drcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(id+1)~=0
+end
+function s.cfilter(c)
 	return c:IsSetCard(0x9f) and c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()
 end
-
-
-function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_HAND,0,1,nil) 
-		and Duel.IsPlayerCanDraw(tp,1) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND,0,1,1,nil)
-	Duel.SendtoGrave(g,REASON_COST)
-
-function s.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.DiscardHand(tp,s.filter,1,1,REASON_EFFECT)~=0 then
-		local ct=Duel.GetOperatedGroup():FilterCount(Card.IsLocation,nil,LOCATION_GRAVE)
-		if ct>0 then
-			Duel.Draw(tp,1,REASON_EFFECT)
-		end
-	end
+function s.drcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_HAND,0,1,nil) end
+	Duel.DiscardHand(tp,s.cfilter,1,1,REASON_COST)
+end
+function s.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function s.drop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
 end

--- a/unofficial/c199900001.lua
+++ b/unofficial/c199900001.lua
@@ -43,9 +43,6 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)
 	end
 end
-function s.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(id+1)~=0
-end
 function s.cfilter(c)
 	return c:IsSetCard(0x9f) and c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()
 end

--- a/unofficial/c199900001.lua
+++ b/unofficial/c199900001.lua
@@ -1,0 +1,36 @@
+--星因士 プロキオン
+--Performapal Dag Daggerman
+local s,id=GetID()
+function s.initial_effect(c)
+	--handes
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_HANDES+CATEGORY_DRAW)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e2:SetCost(s.dcost)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
+	c:RegisterEffect(e1)
+end
+s.listed_series={0x9f}
+function s.filter(c,tp)
+	return c:IsSetCard(0x9f) and c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()
+end
+
+
+function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_HAND,0,1,nil) 
+		and Duel.IsPlayerCanDraw(tp,1) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND,0,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.DiscardHand(tp,s.filter,1,1,REASON_EFFECT)~=0 then
+		local ct=Duel.GetOperatedGroup():FilterCount(Card.IsLocation,nil,LOCATION_GRAVE)
+		if ct>0 then
+			Duel.Draw(tp,1,REASON_EFFECT)
+		end
+	end
+end


### PR DESCRIPTION
https://yugipedia.com/wiki/Performapal_Dag_Daggerman_(anime)

I had a talk with the folks at card-scripting-101 yesterday about adding the Anime version of this card. Thing is we have the Monster effect, but the Pendulum effect is never seen in the anime. KODER convinced me to drop it, pointing out how the visible anime card clearly has 3 lines of Japanese text, and that my proposed `Once per turn: You can target 1 "Performapal" monster in your Graveyard; add it to your hand.`  isn't the full effect.

Today I was checking in on some unofficial cards where there's an effect used AND visible but blurred card text and noticed that some of them have too much text to fit the use case seen in the anime, meaning they have some effects that weren't demonstrated, still, the visible effects got added to the database. This made me want to try one last time to have this card added.

The situation Dag Daggerman is in obviously isn't the same as the situation mentioned above, where they have more effects but only some of them are shown. Dag Daggerman's pendulum effect is NEVER seem in the anime, so my only hope was comparing the anime effect with the TCG release, where the monster effect is an almost 100% match, only difference being the added hard OPT to prevent abuse. This has been done before with Performapal Longphone Bull. In the anime he was only used once (Yu-Gi-Oh! ARC-V: 087), and by usage alone it was unclear if his effect was activated when summoned or only when special summoned. In the only usage sample we have of the card, he was pendulum summoned. The people at Yugipedia came to the conclusion the effect was activated on summon, but your unofficial cards team reached the consensus that it only activated on special summon by using the TCG release as a guideline, making Longphone Bull's anime effect the same as the TCG release without the hard OPT. So I did the exact same thing! I used the TCG Dag Daggerman script as a guideline, and removed the hard OTP to reach the most likely anime effect.

I know this isn't a perfect solution, we can't be 100% sure if what I propose is even one of the anime effect unless the anime writers leak the anime text or the unblurred artwork. Nonetheless, we are still have the power to gather information, be it from card usage, official anime text, or official release text, and by using that data we can make out an effect that closely resembles what's most likely the original anime effect, which IMO is much better than nothing.