### PR TITLE
Add CODEOWNERS [ci skip]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Repository documentation, configuration, and continuous integration
+*             @kevinlul
+
+# Default card script reviewers
+*.lua         @Naim @pyrQ
+
+/unofficial/  @larry126
+/rush/        @ClementLouis
+/skill/       @ClementLouis


### PR DESCRIPTION
This enables automatic requests for review on PRs. The names are from observation.

Documentation: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners