### PR TITLE
Update Fusion effects to match rulings for Predaplant Verte Anaconda

### DIFF
--- a/cards_specific_functions.lua
+++ b/cards_specific_functions.lua
@@ -383,11 +383,14 @@ function Auxiliary.WitchcrafterDiscardCost(f,minc,maxc)
 				end
 			end
 end
---Special Summon limit for the Evil HEROes
+--Special Summon limit for "Evil HERO" Fusionmonsters
 function Auxiliary.EvilHeroLimit(e,se,sp,st)
-	return (Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),EFFECT_SUPREME_CASTLE)
-		and st&SUMMON_TYPE_FUSION~=0)
+	return (Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),EFFECT_SUPREME_CASTLE) and st&SUMMON_TYPE_FUSION~=0)
 		or se:GetHandler():IsCode(CARD_DARK_FUSION)
+end
+--Special Summon limit for "Fossil" Fusion monsters
+function Auxiliary.FossilLimit(e,se,sp,st)
+	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or se:GetHandler():IsCode(CARD_FOSSIL_FUSION)
 end
 function Auxiliary.AddLavaProcedure(c,required,position,filter,value,description)
 	if not required or required < 1 then

--- a/cards_specific_functions.lua
+++ b/cards_specific_functions.lua
@@ -385,11 +385,9 @@ function Auxiliary.WitchcrafterDiscardCost(f,minc,maxc)
 end
 --Special Summon limit for the Evil HEROes
 function Auxiliary.EvilHeroLimit(e,se,sp,st)
-	local chk=SUMMON_TYPE_FUSION+0x10
-	if Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),EFFECT_SUPREME_CASTLE) then
-		chk=SUMMON_TYPE_FUSION
-	end
-	return st&chk==chk
+	return (Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),EFFECT_SUPREME_CASTLE)
+		and st&SUMMON_TYPE_FUSION~=0)
+		or se:GetHandler():IsCode(CARD_DARK_FUSION)
 end
 function Auxiliary.AddLavaProcedure(c,required,position,filter,value,description)
 	if not required or required < 1 then

--- a/cards_specific_functions.lua
+++ b/cards_specific_functions.lua
@@ -385,8 +385,8 @@ function Auxiliary.WitchcrafterDiscardCost(f,minc,maxc)
 end
 --Special Summon limit for "Evil HERO" Fusionmonsters
 function Auxiliary.EvilHeroLimit(e,se,sp,st)
-	return (Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),EFFECT_SUPREME_CASTLE) and st&SUMMON_TYPE_FUSION~=0)
-		or se:GetHandler():IsCode(CARD_DARK_FUSION)
+	return se:GetHandler():IsCode(CARD_DARK_FUSION)
+		or (Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),EFFECT_SUPREME_CASTLE) and st&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION)
 end
 --Special Summon limit for "Fossil" Fusion monsters
 function Auxiliary.FossilLimit(e,se,sp,st)

--- a/cards_specific_functions.lua
+++ b/cards_specific_functions.lua
@@ -291,6 +291,7 @@ function Auxiliary.ReincarnationCheckValue(e,c)
 		c:RegisterFlagEffect(CARD_SALAMANGREAT_SANCTUARY,RESET_EVENT+RESETS_STANDARD-RESET_TOFIELD,0,1,label)
 	end
 end
+
 --Filter for unique on field Malefic monsters
 function Auxiliary.MaleficUniqueFilter(cc)
 	local mt=cc:GetMetatable()
@@ -352,6 +353,7 @@ function Auxiliary.MaleficSummonOperation(cd,loc)
 				g:DeleteGroup()
 			end
 end
+
 --Discard cost for Witchcrafter monsters, supports the replacements from the Continuous Spells
 function Auxiliary.WitchcrafterDiscardFilter(c,tp)
 	return c:IsHasEffect(EFFECT_WITCHCRAFTER_REPLACE,tp) and c:IsAbleToGraveAsCost()
@@ -383,7 +385,8 @@ function Auxiliary.WitchcrafterDiscardCost(f,minc,maxc)
 				end
 			end
 end
---Special Summon limit for "Evil HERO" Fusionmonsters
+
+--Special Summon limit for "Evil HERO" Fusion monsters
 function Auxiliary.EvilHeroLimit(e,se,sp,st)
 	return se:GetHandler():IsCode(CARD_DARK_FUSION)
 		or (Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),EFFECT_SUPREME_CASTLE) and st&SUMMON_TYPE_FUSION==SUMMON_TYPE_FUSION)
@@ -392,6 +395,8 @@ end
 function Auxiliary.FossilLimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or se:GetHandler():IsCode(CARD_FOSSIL_FUSION)
 end
+
+--Kaiju and Lava Golem-like summon procedures
 function Auxiliary.AddLavaProcedure(c,required,position,filter,value,description)
 	if not required or required < 1 then
 		required = 1

--- a/official/c12015000.lua
+++ b/official/c12015000.lua
@@ -3,36 +3,33 @@
 --Scripted by AlphaKretin
 local s,id=GetID()
 function s.initial_effect(c)
-	--fusion material
+	--Fusion material
 	c:EnableReviveLimit()
 	Fusion.AddProcMix(c,true,true,aux.FilterBoolFunctionEx(Card.IsRace,RACE_ROCK),s.ffilter)
-	--special summon condition
+	--Special summon condition
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e0:SetRange(LOCATION_EXTRA)
+	e0:SetValue(aux.FossilLimit)
+	c:RegisterEffect(e0)
+	--Piercing damage
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
-	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e1:SetRange(LOCATION_EXTRA)
-	e1:SetValue(s.splimit)
+	e1:SetCode(EFFECT_PIERCE)
 	c:RegisterEffect(e1)
-	--piercing damage
+	--Add "Fossil Fusion" to hand
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_PIERCE)
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCost(aux.bfgcost)
+	e2:SetTarget(s.thtg)
+	e2:SetOperation(s.thop)
 	c:RegisterEffect(e2)
-	--add "Fossil Fusion" to hand
-	local e3=Effect.CreateEffect(c)
-	e3:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
-	e3:SetType(EFFECT_TYPE_IGNITION)
-	e3:SetRange(LOCATION_GRAVE)
-	e3:SetCost(aux.bfgcost)
-	e3:SetTarget(s.thtg)
-	e3:SetOperation(s.thop)
-	c:RegisterEffect(e3)
 end
 s.listed_names={CARD_FOSSIL_FUSION}
-function s.splimit(e,se,sp,st)
-	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or st==SUMMON_TYPE_FUSION+0x20
-end
 function s.ffilter(c,fc,sumtype,tp)
 	return c:IsLevelBelow(4) and c:IsLocation(LOCATION_GRAVE) and c:IsControler(1-tp)
 end

--- a/official/c12071500.lua
+++ b/official/c12071500.lua
@@ -2,15 +2,88 @@
 --Dark Calling
 local s,id=GetID()
 function s.initial_effect(c)
-	local e1=Fusion.CreateSummonEff(c,function(c) return c.dark_calling end,Fusion.InHandMat(Card.IsAbleToRemove),s.fextra,Fusion.BanishMaterial,nil,nil,nil)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 	if not GhostBelleTable then GhostBelleTable={} end
 	table.insert(GhostBelleTable,e1)
 end
 s.listed_names={CARD_DARK_FUSION}
-function s.fextra(e,tp,mg)
-	if not Duel.IsPlayerAffectedByEffect(tp,69832741) then
-		return Duel.GetMatchingGroup(Fusion.IsMonsterFilter(Card.IsAbleToRemove),tp,LOCATION_GRAVE,0,nil)
+function s.filter0(c)
+	return c:IsLocation(LOCATION_HAND) and c:IsAbleToRemove()
+end
+function s.filter1(c,e)
+	return c:IsLocation(LOCATION_HAND) and c:IsAbleToRemove() and not c:IsImmuneToEffect(e)
+end
+function s.filter2(c,e,tp,m,f,chkf)
+	return c:IsType(TYPE_FUSION) and c.dark_calling and (not f or f(c))
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,true,false) and c:CheckFusionMaterial(m,nil,chkf)
+end
+function s.filter3(c)
+	return c:IsType(TYPE_MONSTER) and c:IsCanBeFusionMaterial() and c:IsAbleToRemove()
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local chkf=tp
+		local mg1=Duel.GetFusionMaterial(tp):Filter(s.filter0,nil)
+		if not Duel.IsPlayerAffectedByEffect(tp,69832741) then
+			local mg2=Duel.GetMatchingGroup(s.filter3,tp,LOCATION_GRAVE,0,nil)
+			mg1:Merge(mg2)
+		end
+		local res=Duel.IsExistingMatchingCard(s.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
+		if not res then
+			local ce=Duel.GetChainMaterial(tp)
+			if ce~=nil then
+				local fgroup=ce:GetTarget()
+				local mg3=fgroup(ce,e,tp)
+				local mf=ce:GetValue()
+				res=Duel.IsExistingMatchingCard(s.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg3,mf,chkf)
+			end
+		end
+		return res
 	end
-	return nil
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,2,tp,LOCATION_HAND+LOCATION_GRAVE)
+end
+function s.activate(e,tp,eg,ep,ev,re,r,rp)
+	local chkf=tp
+	local mg1=Duel.GetFusionMaterial(tp):Filter(s.filter1,nil,e)
+	if not Duel.IsPlayerAffectedByEffect(tp,69832741) then
+		local mg2=Duel.GetMatchingGroup(s.filter3,tp,LOCATION_GRAVE,0,nil)
+		mg1:Merge(mg2)
+	end
+	local sg1=Duel.GetMatchingGroup(s.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,chkf)
+	local mg3=nil
+	local sg2=nil
+	local ce=Duel.GetChainMaterial(tp)
+	if ce~=nil then
+		local fgroup=ce:GetTarget()
+		mg3=fgroup(ce,e,tp)
+		local mf=ce:GetValue()
+		sg2=Duel.GetMatchingGroup(s.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg3,mf,chkf)
+	end
+	if #sg1>0 or (sg2~=nil and #sg2>0) then
+		local sg=sg1:Clone()
+		if sg2 then sg:Merge(sg2) end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tg=sg:Select(tp,1,1,nil)
+		local tc=tg:GetFirst()
+		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
+			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
+			tc:SetMaterial(mat1)
+			Duel.Remove(mat1,POS_FACEUP,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+			Duel.BreakEffect()
+			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,true,false,POS_FACEUP)
+		else
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,tp,chkf)
+			local fop=ce:GetOperation()
+			fop(ce,e,tp,tc,mat2,SUMMON_TYPE_FUSION)
+		end
+		tc:CompleteProcedure()
+	end
 end

--- a/official/c12071500.lua
+++ b/official/c12071500.lua
@@ -2,7 +2,7 @@
 --Dark Calling
 local s,id=GetID()
 function s.initial_effect(c)
-	local e1=Fusion.CreateSummonEff(c,function(c) return c.dark_calling end,Fusion.InHandMat(Card.IsAbleToRemove),s.fextra,Fusion.BanishMaterial,nil,nil,nil,SUMMON_TYPE_FUSION|0x10)
+	local e1=Fusion.CreateSummonEff(c,function(c) return c.dark_calling end,Fusion.InHandMat(Card.IsAbleToRemove),s.fextra,Fusion.BanishMaterial,nil,nil,nil)
 	c:RegisterEffect(e1)
 	if not GhostBelleTable then GhostBelleTable={} end
 	table.insert(GhostBelleTable,e1)

--- a/official/c13293158.lua
+++ b/official/c13293158.lua
@@ -1,17 +1,18 @@
 --E－HERO ワイルド・サイクロン
+--Evil HERO Wild Cyclone
 local s,id=GetID()
 function s.initial_effect(c)
-	--fusion material
 	c:EnableReviveLimit()
+	--Fusion material
 	Fusion.AddProcMix(c,true,true,21844576,86188410)
-	--spsummon condition
+	--Special Summon condition
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e1:SetValue(aux.EvilHeroLimit)
 	c:RegisterEffect(e1)
-	--actlimit
+	--Prevent Spell/Traps activation while battling
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
 	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
@@ -21,7 +22,7 @@ function s.initial_effect(c)
 	e2:SetValue(s.aclimit)
 	e2:SetCondition(s.actcon)
 	c:RegisterEffect(e2)
-	--destroy
+	--Destroy all face-down Spell/Trap
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(id,0))
 	e3:SetCategory(CATEGORY_DESTROY)
@@ -35,9 +36,6 @@ end
 s.material_setcode={0x8,0x3008}
 s.dark_calling=true
 s.listed_names={CARD_DARK_FUSION,21844576,86188410}
-function s.splimit(e,se,sp,st)
-	return st==SUMMON_TYPE_FUSION+0x10
-end
 function s.aclimit(e,re,tp)
 	return re:IsHasType(EFFECT_TYPE_ACTIVATE)
 end

--- a/official/c21225115.lua
+++ b/official/c21225115.lua
@@ -11,7 +11,7 @@ function s.initial_effect(c)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
 	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e0:SetRange(LOCATION_EXTRA)
-	e0:SetValue(s.splimit)
+	e0:SetValue(aux.FossilLimit)
 	c:RegisterEffect(e0)
 	--Increase ATK
 	local e1=Effect.CreateEffect(c)
@@ -38,9 +38,6 @@ end
 s.listed_names={CARD_FOSSIL_FUSION}
 function s.matfilter(c,sc,st,tp)
 	return c:IsLevelAbove(7) and c:IsLocation(LOCATION_GRAVE) and c:IsControler(1-tp)
-end
-function s.splimit(e,se,sp,st)
-	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or st==SUMMON_TYPE_FUSION+0x20
 end
 function s.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/official/c21947653.lua
+++ b/official/c21947653.lua
@@ -1,5 +1,5 @@
 --E－HERO ライトニング・ゴーレム
---21947653
+--Evil HERO Lightning Golem
 local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()

--- a/official/c21947653.lua
+++ b/official/c21947653.lua
@@ -1,34 +1,32 @@
 --E－HERO ライトニング・ゴーレム
+--21947653
 local s,id=GetID()
 function s.initial_effect(c)
-	--fusion material
 	c:EnableReviveLimit()
+	--Fusion material
 	Fusion.AddProcMix(c,true,true,20721928,84327329)
-	--spsummon condition
+	--Special Summon condition
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e0:SetValue(aux.EvilHeroLimit)
+	c:RegisterEffect(e0)
+	--Destroy 1 monster on the field
 	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e1:SetValue(aux.EvilHeroLimit)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetCountLimit(1)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
-	--destroy
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(id,0))
-	e2:SetCategory(CATEGORY_DESTROY)
-	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetCountLimit(1)
-	e2:SetRange(LOCATION_MZONE)
-	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e2:SetTarget(s.target)
-	e2:SetOperation(s.operation)
-	c:RegisterEffect(e2)
 end
 s.material_setcode={0x8,0x3008}
 s.dark_calling=true
 s.listed_names={CARD_DARK_FUSION,20721928,84327329}
-function s.splimit(e,se,sp,st)
-	return st==SUMMON_TYPE_FUSION+0x10
-end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
 	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end

--- a/official/c22160245.lua
+++ b/official/c22160245.lua
@@ -1,17 +1,18 @@
 --E－HERO インフェルノ・ウィング
+--Evil HERO Inferno Wing
 local s,id=GetID()
 function s.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
 	Fusion.AddProcMix(c,true,true,58932615,21844576)
-	--spsummon condition
+	--Special Summon condition
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e1:SetValue(aux.EvilHeroLimit)
 	c:RegisterEffect(e1)
-	--damage
+	--Inflict damage
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_DAMAGE)
@@ -22,7 +23,7 @@ function s.initial_effect(c)
 	e2:SetTarget(s.damtg)
 	e2:SetOperation(s.damop)
 	c:RegisterEffect(e2)
-	--pierce
+	--Piercing damage
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetCode(EFFECT_PIERCE)
@@ -31,9 +32,6 @@ end
 s.material_setcode={0x8,0x3008}
 s.dark_calling=true
 s.listed_names={CARD_DARK_FUSION,58932615,21844576}
-function s.splimit(e,se,sp,st)
-	return st==SUMMON_TYPE_FUSION+0x10
-end
 function s.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local c=e:GetHandler()

--- a/official/c22160245.lua
+++ b/official/c22160245.lua
@@ -2,8 +2,8 @@
 --Evil HERO Inferno Wing
 local s,id=GetID()
 function s.initial_effect(c)
-	--fusion material
 	c:EnableReviveLimit()
+	--Fusion materials
 	Fusion.AddProcMix(c,true,true,58932615,21844576)
 	--Special Summon condition
 	local e1=Effect.CreateEffect(c)

--- a/official/c50282757.lua
+++ b/official/c50282757.lua
@@ -1,44 +1,42 @@
 --E－HERO ヘル・スナイパー
+--Evil HERO Infernal Sniper
 local s,id=GetID()
 function s.initial_effect(c)
-	--fusion material
 	c:EnableReviveLimit()
+	--Fusion material
 	Fusion.AddProcMix(c,true,true,84327329,58932615)
-	--spsummon condition
+	--Special Summon condition
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e0:SetValue(aux.EvilHeroLimit)
+	c:RegisterEffect(e0)
+	--Inflict damage in the Standby Phase
 	local e1=Effect.CreateEffect(c)
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e1:SetValue(aux.EvilHeroLimit)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_DAMAGE)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCondition(s.condition)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
-	--damage
+	--Cannot be destroyed by Spell effects
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(id,0))
-	e2:SetCategory(CATEGORY_DAMAGE)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e2:SetRange(LOCATION_MZONE)
-	e2:SetCountLimit(1)
-	e2:SetCode(EVENT_PHASE+PHASE_STANDBY)
-	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-	e2:SetCondition(s.condition)
-	e2:SetTarget(s.target)
-	e2:SetOperation(s.operation)
+	e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	e2:SetValue(s.indesval)
 	c:RegisterEffect(e2)
-	--indes
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
-	e3:SetValue(s.indesval)
-	c:RegisterEffect(e3)
 end
 s.material_setcode={0x8,0x3008}
 s.dark_calling=true
 s.listed_names={CARD_DARK_FUSION,58932615,84327329}
-function s.splimit(e,se,sp,st)
-	return st==SUMMON_TYPE_FUSION+0x10
-end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPosition(POS_FACEUP_DEFENSE) and Duel.GetTurnPlayer()==tp
 end

--- a/official/c58332301.lua
+++ b/official/c58332301.lua
@@ -18,7 +18,7 @@ function s.initial_effect(c)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetOperation(s.atkop)
 	c:RegisterEffect(e1)
-	--Chnage battle position
+	--Change battle position
 	local e2=Effect.CreateEffect(c)
 	e2:SetCategory(CATEGORY_POSITION)
 	e2:SetDescription(aux.Stringid(id,0))
@@ -30,9 +30,6 @@ function s.initial_effect(c)
 end
 s.dark_calling=true
 s.listed_names={CARD_DARK_FUSION}
-function s.splimit(e,se,sp,st)
-	return st==SUMMON_TYPE_FUSION+0x10
-end
 function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=c:GetMaterial()

--- a/official/c58332301.lua
+++ b/official/c58332301.lua
@@ -2,31 +2,31 @@
 --Evil HERO Dark Gaia
 local s,id=GetID()
 function s.initial_effect(c)
-	--fusion material
 	c:EnableReviveLimit()
+	--Fusion material
 	Fusion.AddProcMix(c,true,true,aux.FilterBoolFunctionEx(Card.IsRace,RACE_FIEND),aux.FilterBoolFunctionEx(Card.IsRace,RACE_ROCK))
-	--spsummon condition
+	--Special Summon condition
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e0:SetValue(aux.EvilHeroLimit)
+	c:RegisterEffect(e0)
+	--Change original ATK
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetOperation(s.atkop)
+	c:RegisterEffect(e1)
+	--Chnage battle position
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e2:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e2:SetValue(aux.EvilHeroLimit)
+	e2:SetCategory(CATEGORY_POSITION)
+	e2:SetDescription(aux.Stringid(id,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetTarget(s.postg)
+	e2:SetOperation(s.posop)
 	c:RegisterEffect(e2)
-	--atk
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
-	e3:SetOperation(s.atkop)
-	c:RegisterEffect(e3)
-	--Pos Change
-	local e3=Effect.CreateEffect(c)
-	e3:SetCategory(CATEGORY_POSITION)
-	e3:SetDescription(aux.Stringid(id,0))
-	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e3:SetCode(EVENT_ATTACK_ANNOUNCE)
-	e3:SetTarget(s.postg)
-	e3:SetOperation(s.posop)
-	c:RegisterEffect(e3)
 end
 s.dark_calling=true
 s.listed_names={CARD_DARK_FUSION}
@@ -36,17 +36,17 @@ end
 function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=c:GetMaterial()
-	local s=0
+	local val=0
 	local tc=g:GetFirst()
 	for tc in aux.Next(g) do
 		local a=tc:GetAttack()
 		if a<0 then a=0 end
-		s=s+a
+		val=val+a
 	end
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SET_BASE_ATTACK)
-	e1:SetValue(s)
+	e1:SetValue(val)
 	e1:SetReset(RESET_EVENT+RESETS_STANDARD_DISABLE)
 	c:RegisterEffect(e1)
 end

--- a/official/c59419719.lua
+++ b/official/c59419719.lua
@@ -5,7 +5,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--activate
 	local e1=Fusion.CreateSummonEff({handler=c,fusfilter=aux.FilterBoolFunction(Card.IsSetCard,0x14c),matfilter=aux.FALSE,extrafil=s.fextra,
-											stage2=s.stage2,value=0x20,extraop=Fusion.BanishMaterial})
+											stage2=s.stage2,extraop=Fusion.BanishMaterial})
 	c:RegisterEffect(e1)
 	if not GhostBelleTable then GhostBelleTable={} end
 	table.insert(GhostBelleTable,e1)

--- a/official/c59531356.lua
+++ b/official/c59531356.lua
@@ -13,7 +13,7 @@ function s.initial_effect(c)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
 	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e0:SetRange(LOCATION_EXTRA)
-	e0:SetValue(s.splimit)
+	e0:SetValue(aux.FossilLimit)
 	c:RegisterEffect(e0)
 	--Inflict piercing battle damage
 	local e1=Effect.CreateEffect(c)
@@ -46,10 +46,6 @@ s.listed_names={id,CARD_FOSSIL_FUSION}
 function s.matfilter(c)
 	local lv=c:GetLevel()
 	return c:HasLevel() and (lv==5 or lv==6)
-end
-	--Handle its special summon condition
-function s.splimit(e,se,sp,st)
-	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or st==SUMMON_TYPE_FUSION+0x20
 end
 	--If able to make a second attack
 function s.atcon(e,tp,eg,ep,ev,re,r,rp)

--- a/official/c70369116.lua
+++ b/official/c70369116.lua
@@ -5,7 +5,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
 	Link.AddProcedure(c,aux.FilterBoolFunctionEx(Card.IsType,TYPE_EFFECT),2,2)
-	--aatribute change
+	--atribute change
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)

--- a/official/c70369116.lua
+++ b/official/c70369116.lua
@@ -5,7 +5,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
 	Link.AddProcedure(c,aux.FilterBoolFunctionEx(Card.IsType,TYPE_EFFECT),2,2)
-	--atribute change
+	--Change attribute to DARK
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
@@ -15,7 +15,7 @@ function s.initial_effect(c)
 	e1:SetTarget(s.attg)
 	e1:SetOperation(s.atop)
 	c:RegisterEffect(e1)
-	--copy spell
+	--Apply the effects of a "Fusion/Polymerization" spell
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,1))
 	e2:SetType(EFFECT_TYPE_IGNITION)

--- a/official/c85808813.lua
+++ b/official/c85808813.lua
@@ -38,7 +38,7 @@ end
 	--Check for "Fossil" fusion monster with 2 levels higher than one in "filter"
 function s.ssfilter(c,lv,e,tp)
 	return c:IsType(TYPE_FUSION) and c:IsSetCard(0x14c) and c:IsLevel(lv+2)
-	and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0 and c:IsCanBeSpecialSummoned(e,0,tp,true,true,POS_FACEUP)
+		and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0 and c:IsCanBeSpecialSummoned(e,0,tp,true,true,POS_FACEUP)
 end
 	--Activation legality
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/official/c86165817.lua
+++ b/official/c86165817.lua
@@ -3,37 +3,37 @@
 --Scripted by Larry126
 local s,id=GetID()
 function s.initial_effect(c)
-	--fusion material
 	c:EnableReviveLimit()
+	--Fusion material
 	Fusion.AddProcMix(c,true,true,aux.FilterBoolFunctionEx(Card.IsSetCard,0x6008),aux.FilterBoolFunctionEx(Card.IsLevelAbove,5))
-	--spsummon condition
+	--Special Summon condition
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e0:SetValue(aux.EvilHeroLimit)
+	c:RegisterEffect(e0)
+	--Cannot be destroyed
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e1:SetValue(aux.EvilHeroLimit)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e1:SetValue(1)
 	c:RegisterEffect(e1)
-	--indes
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-	e2:SetRange(LOCATION_MZONE)
-	e2:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
-	e2:SetValue(1)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
 	c:RegisterEffect(e2)
-	local e3=e2:Clone()
-	e3:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	--Destroy all other monsters
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,0))
+	e3:SetCategory(CATEGORY_DESTROY+CATEGORY_ATKCHANGE)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCountLimit(1,id)
+	e3:SetTarget(s.destg)
+	e3:SetOperation(s.desop)
 	c:RegisterEffect(e3)
-	--destroy
-	local e4=Effect.CreateEffect(c)
-	e4:SetDescription(aux.Stringid(id,0))
-	e4:SetCategory(CATEGORY_DESTROY+CATEGORY_ATKCHANGE)
-	e4:SetType(EFFECT_TYPE_IGNITION)
-	e4:SetRange(LOCATION_MZONE)
-	e4:SetCountLimit(1,id)
-	e4:SetTarget(s.destg)
-	e4:SetOperation(s.desop)
-	c:RegisterEffect(e4)
 end
 s.material_setcode={0x8,0x6008}
 s.dark_calling=true

--- a/official/c86520461.lua
+++ b/official/c86520461.lua
@@ -13,7 +13,7 @@ function s.initial_effect(c)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
 	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e0:SetRange(LOCATION_EXTRA)
-	e0:SetValue(s.splimit)
+	e0:SetValue(aux.FossilLimit)
 	c:RegisterEffect(e0)
 	--Can make 2 attacks on monsters
 	local e1=Effect.CreateEffect(c)
@@ -37,10 +37,6 @@ function s.initial_effect(c)
 end
 	--Specifically lists itself, "Fossil Fusion", and "Time Stream"
 s.listed_names={id,CARD_FOSSIL_FUSION,85808813}
-	--Handle its special summon condition
-function s.splimit(e,se,sp,st)
-	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or se:GetHandler():IsCode(CARD_FOSSIL_FUSION)
-end
 	--Check for "Time Stream"
 function s.thfilter(c)
 	return c:IsCode(85808813) and c:IsAbleToHand()

--- a/official/c86520461.lua
+++ b/official/c86520461.lua
@@ -39,7 +39,7 @@ end
 s.listed_names={id,CARD_FOSSIL_FUSION,85808813}
 	--Handle its special summon condition
 function s.splimit(e,se,sp,st)
-	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or st==SUMMON_TYPE_FUSION+0x20
+	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or se:GetHandler():IsCode(CARD_FOSSIL_FUSION)
 end
 	--Check for "Time Stream"
 function s.thfilter(c)

--- a/official/c86676862.lua
+++ b/official/c86676862.lua
@@ -2,51 +2,47 @@
 --Evil HERO Malicious Fiend
 local s,id=GetID()
 function s.initial_effect(c)
-	--fusion material
 	c:EnableReviveLimit()
+	--Fusion material
 	Fusion.AddProcMix(c,true,true,58554959,s.ffilter)
-	--spsummon condition
+	--Special Summon condition
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_SINGLE)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e0:SetValue(aux.EvilHeroLimit)
+	c:RegisterEffect(e0)
+	--Change all monsters to Attack position
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SET_POSITION)
+	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(0,LOCATION_MZONE)
+	e1:SetCondition(s.poscon)
+	e1:SetValue(POS_FACEUP_ATTACK)
+	c:RegisterEffect(e1)
+	--Monsters must attack
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
-	e2:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e2:SetValue(aux.EvilHeroLimit)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_MUST_ATTACK)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(0,LOCATION_MZONE)
+	e2:SetCondition(s.poscon)
 	c:RegisterEffect(e2)
-	--Pos Change
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetCode(EFFECT_SET_POSITION)
-	e3:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetTargetRange(0,LOCATION_MZONE)
-	e3:SetCondition(s.poscon)
-	e3:SetValue(POS_FACEUP_ATTACK)
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_MUST_ATTACK_MONSTER)
+	e3:SetValue(s.atklimit)
 	c:RegisterEffect(e3)
-	--must attack
-	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_FIELD)
-	e4:SetCode(EFFECT_MUST_ATTACK)
-	e4:SetRange(LOCATION_MZONE)
-	e4:SetTargetRange(0,LOCATION_MZONE)
-	e4:SetCondition(s.poscon)
-	c:RegisterEffect(e4)
-	local e5=e4:Clone()
-	e5:SetCode(EFFECT_MUST_ATTACK_MONSTER)
-	e5:SetValue(s.atklimit)
-	c:RegisterEffect(e5)
 end
 s.material_setcode={0x8,0x6008}
 s.dark_calling=true
 s.listed_names={CARD_DARK_FUSION,58554959}
-function s.splimit(e,se,sp,st)
-	return st==SUMMON_TYPE_FUSION+0x10
-end
 function s.ffilter(c,fc,sumtype,tp)
 	return c:IsRace(RACE_FIEND,fc,sumtype,tp) and c:GetLevel()>=6
 end
 function s.poscon(e)
-	local ph=Duel.GetCurrentPhase()
-	return Duel.GetTurnPlayer()~=e:GetHandlerPlayer() and ph>=0x8 and ph<=0x20
+	return Duel.GetTurnPlayer()==1-e:GetHandlerPlayer() and Duel.IsBattlePhase()
 end
 function s.atklimit(e,c)
 	return c==e:GetHandler()

--- a/official/c94820406.lua
+++ b/official/c94820406.lua
@@ -2,7 +2,7 @@
 --Dark Fusion
 local s,id=GetID()
 function s.initial_effect(c)
-	c:RegisterEffect(Fusion.CreateSummonEff(c,aux.FilterBoolFunction(Card.IsRace,RACE_FIEND),nil,nil,nil,nil,s.stage2,nil,SUMMON_TYPE_FUSION|0x10))
+	c:RegisterEffect(Fusion.CreateSummonEff({handler=c,fusfilter=aux.FilterBoolFunction(Card.IsRace,RACE_FIEND),stage2=s.stage2}))
 end
 function s.stage2(e,tc,tp,sg,chk)
 	if chk==1 then

--- a/official/c96897184.lua
+++ b/official/c96897184.lua
@@ -5,26 +5,26 @@ local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
 	Fusion.AddProcMix(c,true,true,aux.FilterBoolFunctionEx(Card.IsRace,RACE_ROCK),aux.FilterBoolFunctionEx(Card.IsLevelAbove,7))
-	--special summon condition
+	--Special summon condition
 	local e0=Effect.CreateEffect(c)
 	e0:SetType(EFFECT_TYPE_SINGLE)
 	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
 	e0:SetCode(EFFECT_SPSUMMON_CONDITION)
 	e0:SetRange(LOCATION_EXTRA)
-	e0:SetValue(s.splimit)
+	e0:SetValue(aux.FossilLimit)
 	c:RegisterEffect(e0)
-	--extra attack
+	--Extra attack
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_EXTRA_ATTACK)
 	e1:SetValue(1)
 	c:RegisterEffect(e1)
-	--piercing damage
+	--Ppiercing damage
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_PIERCE)
 	c:RegisterEffect(e2)
-	--special summon
+	--Special summon a target from the GY
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(id,0))
 	e3:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_HANDES)
@@ -38,23 +38,21 @@ function s.initial_effect(c)
 	e3:SetOperation(s.spop)
 	c:RegisterEffect(e3)
 end
-function s.splimit(e,se,sp,st)
-	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or st==SUMMON_TYPE_FUSION+0x20
-end
+s.listed_names={CARD_FOSSIL_FUSION}
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()==1-tp
 end
-function s.spfilter(c,e,tp,zone)
+function s.spfilter(c,e,tp)
 	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and chkc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp) end
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and s.spfilter(chkc,e,tp) end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 
-		and Duel.IsExistingTarget(Card.IsCanBeSpecialSummoned,tp,0,LOCATION_GRAVE,1,nil,e,0,tp,false,false,POS_FACEUP,tp) 
+		and Duel.IsExistingTarget(s.spfilter,tp,0,LOCATION_GRAVE,1,nil,e,tp) 
 		and Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil,REASON_EFFECT) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectTarget(tp,Card.IsCanBeSpecialSummoned,tp,0,LOCATION_GRAVE,1,1,nil,e,0,tp,false,false,POS_FACEUP,tp)
+	local g=Duel.SelectTarget(tp,s.spfilter,tp,0,LOCATION_GRAVE,1,1,nil,e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,tp,LOCATION_GRAVE)
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end

--- a/official/c96897184.lua
+++ b/official/c96897184.lua
@@ -19,7 +19,7 @@ function s.initial_effect(c)
 	e1:SetCode(EFFECT_EXTRA_ATTACK)
 	e1:SetValue(1)
 	c:RegisterEffect(e1)
-	--Ppiercing damage
+	--Piercing damage
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_PIERCE)


### PR DESCRIPTION
- [x] **Predaplant Verte Anaconda** must be unable to send **Fossil Fusion** and **Dark Fusion** to apply their effects.
- [x] Fossil monsters must still be summonable from the Extra Deck only with Fossil Fusion.
- [x] They must still be summonable from the GY after being properly summoned first.
- [x] Time Stream must be able to summon them, and treat the summon as a proper summon.
- [x] Evil Hero monsters must still be summonable  from the Extra Deck only with Dark Fusion.
- [x] If Supreme King's Castle is on the field, Evil Hero monsters must be summonable with other fusion effects.
- [x] Dark Calling must also be able to properly summon them.
- [x] They must not be summonable from the GY.