### PR TITLE
Fix "Red Hared Hasty Horse"

### DIFF
--- a/official/c19636995.lua
+++ b/official/c19636995.lua
@@ -26,7 +26,7 @@ function s.initial_effect(c)
 	--custom EVENT_PLACED
 	local e2a=Effect.CreateEffect(c)
 	e2a:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e2a:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e2a:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_IGNORE_IMMUNE)
 	e2a:SetRange(LOCATION_MZONE)
 	e2a:SetCode(EVENT_ADJUST)
 	e2a:SetOperation(s.plchk)


### PR DESCRIPTION
Is there a reason why this card's self destruction effect can't be copied? A bug report was sent in, and I'm not sure of the answer, but being a rather common trigger effect I don't see why not, so I'm removing the UNCOPYABLE flag.
