### PR TITLE
Fix for "Cynet Codec"

### DIFF
--- a/official/c60018643.lua
+++ b/official/c60018643.lua
@@ -59,7 +59,7 @@ function s.regop(e,tp,eg,ep,ev,re,r,rp)
 	local tg=eg:Filter(s.thcfilter,nil,e,tp)
 	if #tg>0 then
 		local g=e:GetLabelObject():GetLabelObject()
-		if Duel.GetCurrentChain()==0 then g:Clear() end
+		if Duel.GetCurrentChain()>0 then g:Clear() end
 		g:Merge(tg)
 		e:GetLabelObject():SetLabelObject(g)
 		Duel.RaiseSingleEvent(e:GetHandler(),EVENT_CUSTOM+id,e,0,tp,tp,0)


### PR DESCRIPTION
Changed Chain check parameter to only look for monsters that were Special Summoned in the same chain as the card's trigger effect activation (group was not clearing after the SS was carried out).

EDIT: Pointed out by @edo9300 that fix was incorrect. Will work on further. 

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

