### PR TITLE
Fix "The Fabled Kokkator"

### DIFF
--- a/official/c26704411.lua
+++ b/official/c26704411.lua
@@ -16,7 +16,7 @@ function s.initial_effect(c)
 end
 s.listed_series={0x35}
 function s.costfilter(c)
-	return c:IsSetCard(0x35) and c:IsDiscardable()
+	return c:IsSetCard(0x35) and c:IsType(TYPE_MONSTER) and c:IsDiscardable()
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.costfilter,tp,LOCATION_HAND,0,1,nil) end


### PR DESCRIPTION
Should only be able to discard "Fabled" monsters, not any "Fabled" card.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
