### PR TITLE
Fix for "Fabled Rudyruda"

### DIFF
--- a/official/c94845226.lua
+++ b/official/c94845226.lua
@@ -1,4 +1,5 @@
 --魔轟神獣ルビィラーダ
+--The Fabled Rudyruda
 local s,id=GetID()
 function s.initial_effect(c)
 	--spsummon
@@ -12,7 +13,7 @@ function s.initial_effect(c)
 end
 s.listed_series={0x35}
 function s.cfilter(c)
-	return c:IsSetCard(0x35) and c:IsDiscardable()
+	return c:IsSetCard(0x35) and c:IsType(TYPE_MONSTER) and c:IsDiscardable()
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_HAND,0,1,nil) end


### PR DESCRIPTION
Should only be able to discard "Fabled" monsters for cost.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

