### PR TITLE
Fix for "Number Karma"

### DIFF
--- a/unofficial/c511001792.lua
+++ b/unofficial/c511001792.lua
@@ -1,3 +1,4 @@
+--ナンバーズ・カルマ
 --Number Karma
 local s,id=GetID()
 function s.initial_effect(c)
@@ -12,7 +13,6 @@ function s.initial_effect(c)
 	e2:SetCode(EVENT_PHASE+PHASE_END)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCountLimit(1)
-	e2:SetCondition(s.damcon)
 	e2:SetTarget(s.damtg)
 	e2:SetOperation(s.damop)
 	c:RegisterEffect(e2)
@@ -20,15 +20,18 @@ end
 function s.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x48)
 end
-function s.damcon(e,tp,eg,ep,ev,re,r,rp)
-	return not Duel.IsExistingMatchingCard(s.cfilter,Duel.GetTurnPlayer(),LOCATION_MZONE,0,1,nil)
-end
 function s.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,PLAYER_ALL,500)
 end
 function s.damop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Damage(1-tp,500,REASON_EFFECT,true)
-	Duel.Damage(tp,500,REASON_EFFECT,true)
+	local g1=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_MZONE,0,nil)
+	local g2=Duel.GetMatchingGroup(s.cfilter,1-tp,LOCATION_MZONE,0,nil)
+	if #g1==0 then
+		Duel.Damage(tp,500,REASON_EFFECT,true)
+	end
+	if #g2==0 then
+		Duel.Damage(1-tp,500,REASON_EFFECT,true)
+	end
 	Duel.RDComplete()
 end


### PR DESCRIPTION
Should only inflict damage to the player(s) that do not control a face-up "Number" monster.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

