### PR TITLE
Fix for "The Shallow Grave (Anime)"

### DIFF
--- a/unofficial/c511002531.lua
+++ b/unofficial/c511002531.lua
@@ -12,7 +12,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.filter(c,e,tp)
-	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end


### PR DESCRIPTION
Incorrectly allowed player to target Link Monsters in GY, and would resolve without going through effect on their side of the field.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
