### PR TITLE
Vampire Sucker Fix

### DIFF
--- a/official/c37129797.lua
+++ b/official/c37129797.lua
@@ -74,7 +74,7 @@ function s.drfilter(c)
 		and c:IsSummonLocation(LOCATION_GRAVE)
 end
 function s.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(s.drfilter,1,nil) and not eg:IsContains(e:GetHandler())
+	return eg:IsExists(s.drfilter,1,e:GetHandler())
 end
 function s.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
Updated the Vampire Sucker Filter following Edo's intruction so it can trigger when Vampire sucker is summoned at the same time as another zombie monster from the gy like it should according to the following ruling: https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21709&request_locale=ja