### PR TITLE
Fix for "White Aura Whale (Manga)"

### DIFF
--- a/unofficial/c511009635.lua
+++ b/unofficial/c511009635.lua
@@ -69,7 +69,7 @@ function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsReason(REASON_DESTROY)
 end
 function s.cfilter(c)
-	return c:IsWhite() and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(true)
+	return c:IsWhite() and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c,true)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,e:GetHandler()) end


### PR DESCRIPTION
Missing card parameter for SpElim filter caused error when attempting to activate banish from GY effect.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

