### PR TITLE
Update for "utility.lua"

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -719,6 +719,15 @@ function Auxiliary.bfgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(c,POS_FACEUP,REASON_COST)
 end
 
+--Cost for detaching exactly x Xyz materials
+function Auxiliary.doccost(x)
+	return function(e,tp,eg,ep,ev,re,r,rp,chk)
+		local c=e:GetHandler()
+		if chk==0 then return c:CheckRemoveOverlayCard(tp,x,REASON_COST) end
+		c:RemoveOverlayCard(tp,x,x,REASON_COST)
+	end
+end
+
 function Auxiliary.EquipByEffectLimit(e,c)
 	if e:GetOwner()~=c then return false end
 	local eff={c:GetCardEffect(89785779+EFFECT_EQUIP_LIMIT)}

--- a/utility.lua
+++ b/utility.lua
@@ -721,7 +721,7 @@ end
 
 --Cost for detaching a minimum of "min" and a maximum of "max" Xyz materials. When called with min="nil", it will detach all Xyz materials.
 --Will also set the number of detached materials as a label if called with label=true true due to the potential need of said number in the operation.
-ffunction Auxiliary.doccost(min,max,label)
+function Auxiliary.doccost(min,max,label)
     return function(e,tp,eg,ep,ev,re,r,rp,chk)
         local c=e:GetHandler()
         local min=min or c:GetOverlayCount()

--- a/utility.lua
+++ b/utility.lua
@@ -719,19 +719,32 @@ function Auxiliary.bfgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(c,POS_FACEUP,REASON_COST)
 end
 
---Cost for detaching a minimum of "min" and a maximum of "max" Xyz materials. When called with "nil" or an empty parameter list, it will detach all Xyz materials.
---Will also check for a suitable data type and set the number of detached materials as a label due to the potential need of said number in the operation.
-function Auxiliary.doccost(min,max)
+--Cost for detaching a minimum of "min" and a maximum of "max" Xyz materials. When called with "nil", it will detach all Xyz materials.
+--Will also check for a suitable data type and set the number of detached materials as a label if supplied with true as parameter 2 if
+--no second integer is supplied or as parameter 3 if a second integer is supplied due to the potential need of said number in the operation.
+function Auxiliary.doccost(min,...)
+	local params={...}
+	local max,label
+	if type(params[1])=='boolean' then
+		label=params[1]
+		elseif type(params[1])=='number' and type(params[2])=='boolean' then 
+			max,label=params[1],params[2]
+			elseif type(params[1])=='number' and not params[2] then
+				max=params[1]
+	end
 	return function(e,tp,eg,ep,ev,re,r,rp,chk)
 		local c=e:GetHandler()
-		local min=min or c:GetOverlayCount()
-		local max=max or min
+		min=min or c:GetOverlayCount()
+		max=max or min
+		label=label or false
 		if type(min)~='number' or type(max)~='number' then
 			error("Parameter "..((type(min)~='number' and '1') or (type(max)~='number' and '2')).." expected to be an integer.")
 		end
 		if chk==0 then return c:CheckRemoveOverlayCard(tp,min,REASON_COST) end
 		c:RemoveOverlayCard(tp,min,max,REASON_COST)
-		e:SetLabel(#Duel.GetOperatedGroup())
+		if label==true then 
+			e:SetLabel(#Duel.GetOperatedGroup())
+		end
 	end
 end
 

--- a/utility.lua
+++ b/utility.lua
@@ -719,12 +719,19 @@ function Auxiliary.bfgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(c,POS_FACEUP,REASON_COST)
 end
 
---Cost for detaching exactly x Xyz materials
-function Auxiliary.doccost(x)
+--Cost for detaching a minimum of "min" and a maximum of "max" Xyz materials. When called with "nil" or an empty parameter list, it will detach all Xyz materials.
+--Will also check for a suitable data type and set the number of detached materials as a label due to the potential need of said number in the operation.
+function Auxiliary.doccost(min,max)
 	return function(e,tp,eg,ep,ev,re,r,rp,chk)
 		local c=e:GetHandler()
-		if chk==0 then return c:CheckRemoveOverlayCard(tp,x,REASON_COST) end
-		c:RemoveOverlayCard(tp,x,x,REASON_COST)
+		local min=min or c:GetOverlayCount()
+		local max=max or min
+		if type(min)~='number' or type(max)~='number' then
+			error("Parameter "..((type(min)~='number' and '1') or (type(max)~='number' and '2')).." expected to be an integer.")
+		end
+		if chk==0 then return c:CheckRemoveOverlayCard(tp,min,REASON_COST) end
+		c:RemoveOverlayCard(tp,min,max,REASON_COST)
+		e:SetLabel(#Duel.GetOperatedGroup())
 	end
 end
 

--- a/utility.lua
+++ b/utility.lua
@@ -719,33 +719,20 @@ function Auxiliary.bfgcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Remove(c,POS_FACEUP,REASON_COST)
 end
 
---Cost for detaching a minimum of "min" and a maximum of "max" Xyz materials. When called with "nil", it will detach all Xyz materials.
---Will also check for a suitable data type and set the number of detached materials as a label if supplied with true as parameter 2 if
---no second integer is supplied or as parameter 3 if a second integer is supplied due to the potential need of said number in the operation.
-function Auxiliary.doccost(min,...)
-	local params={...}
-	local max,label
-	if type(params[1])=='boolean' then
-		label=params[1]
-		elseif type(params[1])=='number' and type(params[2])=='boolean' then 
-			max,label=params[1],params[2]
-			elseif type(params[1])=='number' and not params[2] then
-				max=params[1]
-	end
-	return function(e,tp,eg,ep,ev,re,r,rp,chk)
-		local c=e:GetHandler()
-		min=min or c:GetOverlayCount()
-		max=max or min
-		label=label or false
-		if type(min)~='number' or type(max)~='number' then
-			error("Parameter "..((type(min)~='number' and '1') or (type(max)~='number' and '2')).." expected to be an integer.")
-		end
-		if chk==0 then return c:CheckRemoveOverlayCard(tp,min,REASON_COST) end
-		c:RemoveOverlayCard(tp,min,max,REASON_COST)
-		if label==true then 
-			e:SetLabel(#Duel.GetOperatedGroup())
-		end
-	end
+--Cost for detaching a minimum of "min" and a maximum of "max" Xyz materials. When called with min="nil", it will detach all Xyz materials.
+--Will also set the number of detached materials as a label if called with label=true true due to the potential need of said number in the operation.
+ffunction Auxiliary.doccost(min,max,label)
+    return function(e,tp,eg,ep,ev,re,r,rp,chk)
+        local c=e:GetHandler()
+        local min=min or c:GetOverlayCount()
+        local max=max or min
+        local label=label or false
+        if chk==0 then return c:CheckRemoveOverlayCard(tp,min,REASON_COST) end
+        c:RemoveOverlayCard(tp,min,max,REASON_COST)
+        if label==true then 
+            e:SetLabel(#Duel.GetOperatedGroup())
+        end
+    end
 end
 
 function Auxiliary.EquipByEffectLimit(e,c)


### PR DESCRIPTION
Added the function "aux.doccost" (detach overlay card cost) for detaching x Xyz materials from a card to shorten scripts of Xyz monsters which detach materials as a cost.
- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

