### PR TITLE
Fix for "Frightfur Meister (Manga)"

### DIFF
--- a/unofficial/c511600064.lua
+++ b/unofficial/c511600064.lua
@@ -1,5 +1,5 @@
---デストーイ・マイスター (Anime)
---Frightfur Meister (Anime)
+--デストーイ・マイスター (Manga)
+--Frightfur Meister (Manga)
 --scripted by Larry126
 local s,id=GetID()
 function s.initial_effect(c)

--- a/unofficial/c511600064.lua
+++ b/unofficial/c511600064.lua
@@ -77,7 +77,7 @@ function s.filter(c)
 	return c:IsFaceup() and c:IsSetCard(0xad) and c:IsType(TYPE_MONSTER)
 end
 function s.atkcon(e)
-	return Duel.IsExistingMatchingCard(s.filter,e:GetHandlerPlayer(),LOCATION_MZONE,LOCATION_MZONE,1,nil)
+	return Duel.IsExistingMatchingCard(s.filter,e:GetHandlerPlayer(),LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler())
 end
 function s.cfilter(c,code)
 	return c:IsFaceup() and c:IsCode(code)


### PR DESCRIPTION
Should only be able to be untargetable for attacks if another "Frightfur" monster is on the field except for "Frightfur Meister".

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

