### PR TITLE
Fix for "Orichalcos Kyutora"

### DIFF
--- a/unofficial/c170000166.lua
+++ b/unofficial/c170000166.lua
@@ -54,6 +54,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e,tp):GetFirst()
 	if tc then
+		Duel.SpecialSummon(tc,0,tp,tp,true,false,POS_FACEUP)
 		local e1=Effect.CreateEffect(tc)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_SET_BASE_ATTACK)

--- a/unofficial/c170000166.lua
+++ b/unofficial/c170000166.lua
@@ -3,7 +3,7 @@
 local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
-	--special summon
+	--Special Summon from hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_SPSUMMON_PROC)
@@ -12,7 +12,7 @@ function s.initial_effect(c)
 	e1:SetCondition(s.spcon)
 	e1:SetOperation(s.spop)
 	c:RegisterEffect(e1)
-	--Negates Battle Damage
+	--No Battle Damage
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e2:SetRange(LOCATION_MZONE)
@@ -20,7 +20,7 @@ function s.initial_effect(c)
 	e2:SetCondition(s.rdcon)
 	e2:SetOperation(s.rdop)
 	c:RegisterEffect(e2)
-	--special summon
+	--Special Summon Orichalcos Shunoros
 	local e3=Effect.CreateEffect(c)
 	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)

--- a/unofficial/c170000166.lua
+++ b/unofficial/c170000166.lua
@@ -47,7 +47,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_HAND)
 end
 function s.filter(c,e,tp)
-	return c:Alias()=7634581 and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:Alias()==7634581 and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end

--- a/unofficial/c170000166.lua
+++ b/unofficial/c170000166.lua
@@ -47,7 +47,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_HAND)
 end
 function s.filter(c,e,tp)
-	return c:Alias()==7634581 and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+	return c:IsCode(7634581) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end


### PR DESCRIPTION
Damage was only applying to Kyutora and not to other monsters controlled by the player (e4 was also contributing to the issue, and was extraneous since e2 reduced the damage to 0 anyway). Also changed it so that OCG Shunoros could not be SS'd by this effect (OCG Shunoros requires a Normal monster to be destroyed to be SS'd).

https://github.com/ProjectIgnis/CardScripts/issues/185 - In response to this issue

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
