### PR TITLE
Fix for "The Phantom Knights' Round Blaze"

### DIFF
--- a/unofficial/c511009328.lua
+++ b/unofficial/c511009328.lua
@@ -1,4 +1,5 @@
---The Phantom Knights of Around Burn
+--ファントム・ナイツ・アラウンド・バーン
+--The Phantom Knights' Round Blaze
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -53,7 +54,8 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SkipPhase(Duel.GetTurnPlayer(),PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e1:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	--e1:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e1:SetCode(EVENT_ADJUST)
 	e1:SetCountLimit(1)
 	e1:SetOperation(s.damop)
 	e1:SetReset(RESET_PHASE+PHASE_BATTLE)


### PR DESCRIPTION
Conflicting operations of skipping phase and calculating damage at end of BP made the card never enter the damage calculation operation. Added JP and corrected EN name

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).


