### PR TITLE
Update "Thunder Unicorn (Anime)"

### DIFF
--- a/unofficial/c511002706.lua
+++ b/unofficial/c511002706.lua
@@ -1,4 +1,4 @@
---サンダー・ユニコーン
+--サンダー・ユニコーン (Anime)
 --Thunder Unicorn (Anime)
 local s,id=GetID()
 function s.initial_effect(c)

--- a/unofficial/c511002706.lua
+++ b/unofficial/c511002706.lua
@@ -67,7 +67,7 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
 		e1:SetValue(atk)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e1)
 	end
 end


### PR DESCRIPTION
ATK change was resetting during EP when card proxy was not indicating such a reset existed.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).


