### PR TITLE
Fix for "Unsinkable Titanica"

### DIFF
--- a/unofficial/c100000544.lua
+++ b/unofficial/c100000544.lua
@@ -57,7 +57,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) and tc:IsControler(1-tp) then
 		local atk=tc:GetAttack()
-		if atk<0 or c:IsFacedown() then atk=0 end
+		if atk<0 or tc:IsFacedown() then atk=0 end
 		if Duel.Destroy(tc,REASON_EFFECT)~=0 then
 			Duel.Damage(1-tp,atk/2,REASON_EFFECT)
 		end


### PR DESCRIPTION
Misnamed parameter was causing destroy effect to not carry through.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

