### PR TITLE
Fix for "Guardian Force"

### DIFF
--- a/unofficial/c511000284.lua
+++ b/unofficial/c511000284.lua
@@ -15,8 +15,11 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 s.listed_series={0x52}
+function s.filter(c)
+	return c:IsSetCard(0x52) and c:IsType(TYPE_MONSTER)
+end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return not Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_GRAVE,0,1,nil,0x52) 
+	return not Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_GRAVE,0,1,nil) 
 		and re:IsActiveType(TYPE_SPELL) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev) and rp~=tp
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
Should only check if there are Guardian monsters in the GY, not all Guardian cards

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

