### PR TITLE
Fix for "Chaos Rising"

### DIFF
--- a/unofficial/c511002798.lua
+++ b/unofficial/c511002798.lua
@@ -16,7 +16,7 @@ s.listed_series={0x1048}
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()
 	local d=Duel.GetAttackTarget()
-	return ep==tp and ev>=2000 and (a:IsSetCard(0x1048) or (d and d:IsSetCard(0x1048))) and (a:IsControler(1-tp) or d:IsControler(1-tp))
+	return ep==tp and ev>=2000 and (a:IsSetCard(0x1048) and a:IsControler(1-tp) or (d and d:IsSetCard(0x1048) and d:IsControler(1-tp)))
 end
 function s.spfilter(c,e,tp)
 	return c:IsSetCard(0x1048) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/unofficial/c511002798.lua
+++ b/unofficial/c511002798.lua
@@ -16,7 +16,7 @@ s.listed_series={0x1048}
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()
 	local d=Duel.GetAttackTarget()
-	return ep==tp and ev>=2000 and (a:IsSetCard(0x1048) or (d and d:IsSetCard(0x1048)))
+	return ep==tp and ev>=2000 and (a:IsSetCard(0x1048) or (d and d:IsSetCard(0x1048))) and (a:IsControler(1-tp) or d:IsControler(1-tp))
 end
 function s.spfilter(c,e,tp)
 	return c:IsSetCard(0x1048) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)


### PR DESCRIPTION
Should only activate if the opponent's 'Number C' monster deals damage to this card's controller, not if the controller takes damage involving a 'Number C' monster they control.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

