### PR TITLE
Change for "Cursed Bamboo Sword"

### DIFF
--- a/official/c42199039.lua
+++ b/official/c42199039.lua
@@ -40,16 +40,16 @@ function s.dtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
-	local ec=c:GetEquipTarget()
 	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
-		Duel.ConfirmCards(1-tp,tc)
-		if ec==tc then return end
-		local e1=Effect.CreateEffect(c)
-		e1:SetType(EFFECT_TYPE_SINGLE)
-		e1:SetCode(EFFECT_DIRECT_ATTACK)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-		ec:RegisterEffect(e1)
-	end
+        Duel.ConfirmCards(1-tp,tc)
+        local ec=c:GetEquipTarget()
+        if not ec then return end
+        local e1=Effect.CreateEffect(c)
+        e1:SetType(EFFECT_TYPE_SINGLE)
+        e1:SetCode(EFFECT_DIRECT_ATTACK)
+        e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+        ec:RegisterEffect(e1)
+    end
 end
 function s.thfilter(c)
 	return c:IsSetCard(0x60) and not c:IsCode(id) and c:IsAbleToHand()

--- a/official/c42199039.lua
+++ b/official/c42199039.lua
@@ -41,15 +41,15 @@ function s.dtop(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
-        Duel.ConfirmCards(1-tp,tc)
-        local ec=c:GetEquipTarget()
-        if not ec then return end
-        local e1=Effect.CreateEffect(c)
-        e1:SetType(EFFECT_TYPE_SINGLE)
-        e1:SetCode(EFFECT_DIRECT_ATTACK)
-        e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-        ec:RegisterEffect(e1)
-    end
+		Duel.ConfirmCards(1-tp,tc)
+		local ec=c:GetEquipTarget()
+		if not ec then return end
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_DIRECT_ATTACK)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		ec:RegisterEffect(e1)
+	end
 end
 function s.thfilter(c)
 	return c:IsSetCard(0x60) and not c:IsCode(id) and c:IsAbleToHand()

--- a/official/c42199039.lua
+++ b/official/c42199039.lua
@@ -40,9 +40,10 @@ function s.dtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
+	local ec=c:GetEquipTarget()
 	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) then
 		Duel.ConfirmCards(1-tp,tc)
-		local ec=c:GetEquipTarget()
+		if ec==tc then return end
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_DIRECT_ATTACK)


### PR DESCRIPTION
Changed the operation such that the script won't error anymore if you bounce the monster the card is equipped to. Although there are no official Bamboo Sword monsters, the script doesn't change a single thing when bouncing a different card. The changes are also tested thouroughly before opening this PR and I asked Hel whether this is even feasable. No objections from them, so I think I can give it a try.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

Supervising staff member(s): Hel
