### PR TITLE
Fix for "Trike Fox of the Beast Gear World"

### DIFF
--- a/rush/c160003030.lua
+++ b/rush/c160003030.lua
@@ -17,7 +17,7 @@ end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	return c:IsSummonType(SUMMON_TYPE_NORMAL) and c:IsStatus(STATUS_SUMMON_TURN)
-		and Duel.GetFieldGroupCountRush(tp,0,LOCATION_SZONE)
+		and Duel.GetFieldGroupCountRush(tp,0,LOCATION_MZONE)==3
 end
 function s.filter(c,e,sp)
 	return c:IsRace(RACE_BEASTWARRIOR) and c:IsLevelBelow(7) and c:IsCanBeSpecialSummoned(e,0,sp,false,false,POS_FACEUP)


### PR DESCRIPTION
Should be checking if your opponent controls 3 monsters.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
