### PR TITLE
Small Fix for Yamoimori (again)

### DIFF
--- a/official/c51474037.lua
+++ b/official/c51474037.lua
@@ -31,7 +31,7 @@ end
 function s.btg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
 	local g1,g2=Duel.GetMatchingGroup(aux.FilterFaceupFunction(s.mfilter,e,tp),tp,LOCATION_MZONE,LOCATION_MZONE,nil):Split(Card.IsControler,nil,tp)
-	if chk==0 and #g1+#g2==0 then return false end
+	if chk==0 and (#g1==0 or #g2==0) then return false end
 	local check1=g1:IsExists(Card.IsCanChangePosition,1,nil) and g2:IsExists(Card.IsCanChangePosition,1,nil)
 	local check2=g1:IsExists(Card.IsDestructable,1,nil) and g2:IsExists(Card.IsAttackAbove,1,nil,1)
 	if chk==0 then return check1 or check2 end


### PR DESCRIPTION
Changed the check in line 34 to prevent one group having all members and the other one having none.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

~~Edo, check properly~~
jk friend :)