### PR TITLE
Add "aux.EffectCheck"

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -1534,6 +1534,21 @@ function Auxiliary.ChangeBattleDamage(player,value)
 		end
 end
 
+function Auxiliary.EffectCheck(tp,cons,strings,ops)
+	return function(e,tp,eg,ep,ev,re,r,rp)
+		local eff,sel={},{}
+		for i,con in ipairs(cons) do
+			if con then
+				table.insert(eff,strings[i])
+				table.insert(sel,i)
+			end
+		end
+		local choice=Duel.SelectOption(tp,table.unpack(eff))
+		if ops then ops[sel[choice+1]](e,tp,eg,ep,ev,re,r,rp) end
+		return sel[choice+1]
+	end
+end
+
 Duel.LoadScript("cards_specific_functions.lua")
 Duel.LoadScript("proc_fusion.lua")
 Duel.LoadScript("proc_fusion_spell.lua")


### PR DESCRIPTION
A function to turn tedious choice effects into one-liners.
- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
Supervising staff member(s): Hatter,Hel
 Here's a little usage example:
 
 local t1,t2,t3={ss,set,th,td,tg},{aux.Stringid(id,5),aux.Stringid(id,6),aux.Stringid(id,7),aux.Stringid(id,8),aux.Stringid(id,9)},{s.ssop,s.setop,s.thop,s.tdop,s.tgop}
aux.EffectCheck(tp,t1,t2,t3)(e,tp,eg,ep,ev,re,r,rp)

The function takes the selecting player and 3 tables as params: 1st tab contains the necessary conditions as booleans, 2nd contains the shown strings and the 3rd is optional and contains functions. If the 3rd table isn't nil, then the function corresponding to the selected option will be executed. The index of the selected option is returned in case that you choose in the target and nothing should be executed just yet.

If a more fitting name is found, feel free to rename :3