### PR TITLE
Attempt some changes to speed up fusion procedure

### DIFF
--- a/official/c74063034.lua
+++ b/official/c74063034.lua
@@ -24,14 +24,14 @@ s.listed_names={86120751}
 function s.matfilter(c)
 	return (c:IsLocation(LOCATION_HAND) and c:IsAbleToGrave()) or (c:IsOnField() and c:IsAbleToRemove())
 end
-function s.checkmat(tp,sg,fc)
-	return fc:IsSetCard(0xf4) or not sg:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE+LOCATION_ONFIELD)
+function s.groupfil(mg,fc,gc)
+	return fc:IsSetCard(0xf4) and mg or mg:Filter(Card.IsLocation,nil,LOCATION_HAND)
 end
 function s.fextra(e,tp,mg)
 	if not Duel.IsPlayerAffectedByEffect(tp,69832741) then
-		return Duel.GetMatchingGroup(Fusion.IsMonsterFilter(Card.IsAbleToRemove),tp,LOCATION_GRAVE,LOCATION_GRAVE,nil),s.checkmat
+		return Duel.GetMatchingGroup(Fusion.IsMonsterFilter(Card.IsAbleToRemove),tp,LOCATION_GRAVE,LOCATION_GRAVE,nil),nil,s.groupfil
 	end
-	return nil,s.checkmat
+	return nil,nil,s.groupfil
 end
 function s.extraop(e,tc,tp,sg)
 	local rg=sg:Filter(Card.IsLocation,nil,LOCATION_GRAVE+LOCATION_ONFIELD)

--- a/proc_fusion.lua
+++ b/proc_fusion.lua
@@ -318,12 +318,12 @@ function Fusion.ConditionMixRep(insf,sub,fun1,minc,maxc,...)
 				if not mg:Includes(mustg) or mustg:IsExists(aux.NOT(Card.IsCanBeFusionMaterial),1,nil,c,sumtype) then return false end
 				if gc then
 					if gc:IsExists(aux.NOT(Card.IsCanBeFusionMaterial),1,nil,c,sumtype)
-						or gc:IsExists(aux.NOT(Fusion.ConditionFilterMix),1,nil,c,sub,sub,contact,sumtype,matcheck,tp,fun1,table.unpack(funs))then return false end
+						or gc:IsExists(aux.NOT(Fusion.ConditionFilterMix),1,nil,c,sub,sub,contact,sumtype,matcheck,tp,fun1,table.unpack(funs)) then return false end
 					mustg:Merge(gc)
 				end
 				local sg=Group.CreateGroup()
 				mg:Merge(mustg)
-				return mg:IsExists(Fusion.SelectMixRep,1,nil,tp,mg,sg,mustg,c,sub,sub,contact,sumtype,chkf,fun1,minc,maxc,table.unpack(funs)) 
+				return mg:IsExists(Fusion.SelectMixRep,1,nil,tp,mg,sg,mustg,c,sub,sub,contact,sumtype,chkf,fun1,minc,maxc,table.unpack(funs))
 			end
 end
 function Fusion.OperationMixRep(insf,sub,fun1,minc,maxc,...)

--- a/proc_fusion.lua
+++ b/proc_fusion.lua
@@ -355,11 +355,12 @@ function Fusion.OperationMixRep(insf,sub,fun1,minc,maxc,...)
 				local p=tp
 				local sfhchk=false
 				if not contact and Duel.IsPlayerAffectedByEffect(tp,511004008) and Duel.SelectYesNo(1-tp,65) then
-					p=1-tp Duel.ConfirmCards(1-tp,mg)
+					p=1-tp
+					Duel.ConfirmCards(1-tp,mg)
 					if mg:IsExists(Card.IsLocation,1,nil,LOCATION_HAND) then sfhchk=true end
 				end
+				local cg=mg:Filter(Fusion.SelectMixRep,sg,tp,mg,sg,mustg,c,sub,sub,contact,sumtype,chkf,fun1,minc,maxc,table.unpack(funs))
 				while #sg<maxc+#funs do
-					local cg=mg:Filter(Fusion.SelectMixRep,sg,tp,mg,sg,mustg,c,sub,sub,contact,sumtype,chkf,fun1,minc,maxc,table.unpack(funs))
 					if #cg==0 then break end
 					local finish=Fusion.CheckMixRepGoal(tp,sg,mustg,c,sub,sub,contact,sumtype,chkf,fun1,minc,maxc,table.unpack(funs)) and not Fusion.CheckExact and not (Fusion.CheckMin and #sg<Fusion.CheckMin)
 					local cancel=(contact and #sg==0)
@@ -369,8 +370,15 @@ function Fusion.OperationMixRep(insf,sub,fun1,minc,maxc,...)
 					if #mustg==0 or not mustg:IsContains(tc) then
 						if not sg:IsContains(tc) then
 							sg:AddCard(tc)
+							cg=mg:Filter(Fusion.SelectMixRep,sg,tp,mg,sg,mustg,c,sub,sub,contact,sumtype,chkf,fun1,minc,maxc,table.unpack(funs))
 						else
 							sg:RemoveCard(tc)
+							local cg2=mg:Filter(Fusion.SelectMixRep,sg,tp,mg,sg,mustg,c,sub,sub,contact,sumtype,chkf,fun1,minc,maxc,table.unpack(funs))
+							if #cg2>0 then
+								cg=cg2
+							else
+								sg:AddCard(tc)
+							end
 						end
 					end
 				end
@@ -415,15 +423,15 @@ function Fusion.CheckMixRepTemplate(c,cond,tp,mg,sg,mustg,g,fc,sub,sub2,contact,
 			if res then return true end
 		end
 	end
-	if maxc>0 then
-		if fun1(c,fc,sub,sub2,mg,sg,tp,contact,sumtype) then
-			g:AddCard(c)
-			local sub=sub and fun1(c,fc,false,sub2,mg,sg,tp,contact,sumtype)
-			local res=cond(tp,mg,sg,mustg-c,g,fc,sub,sub2,contact,sumtype,chkf,fun1,minc-1,maxc-1,...)
-			g:RemoveCard(c)
-			if res then return true end
-		end
-	end
+	-- if maxc>0 then
+		-- if fun1(c,fc,sub,sub2,mg,sg,tp,contact,sumtype) then
+			-- g:AddCard(c)
+			-- local sub=sub and fun1(c,fc,false,sub2,mg,sg,tp,contact,sumtype)
+			-- local res=cond(tp,mg,sg,mustg-c,g,fc,sub,sub2,contact,sumtype,chkf,fun1,minc-1,maxc-1,...)
+			-- g:RemoveCard(c)
+			-- if res then return true end
+		-- end
+	-- end
 	return false
 end
 function Fusion.CheckMixRepSelectedCond(tp,mg,sg,mustg,g,...)

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -64,9 +64,9 @@ function Fusion.RegisterSummonEff(c,...)
 	Card.RegisterEffect((tab and c["handler"] or c),e1)
 	return e1
 end
-function Fusion.SummonEffFilter(c,fusfilter,e,tp,mg,gc,chkf,value,sumlimit,nosummoncheck)
+function Fusion.SummonEffFilter(c,fusfilter,e,tp,mg,gc,chkf,value,sumlimit,nosummoncheck,sumpos,groupfilter)
 	return c:IsType(TYPE_FUSION) and (not fusfilter or fusfilter(c,tp)) and (nosummoncheck or c:IsCanBeSpecialSummoned(e,value,tp,sumlimit,false,sumpos))
-			and c:CheckFusionMaterial(mg,gc,chkf)
+			and c:CheckFusionMaterial(not groupfilter and mg or groupfilter(mg,c,gc),gc,chkf)
 end
 
 Fusion.ForcedMatValidity=function(c,e)
@@ -108,6 +108,7 @@ function(fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locati
 				if chk==0 then
 					local mg1=Duel.GetFusionMaterial(tp):Filter(matfilter,nil,e,tp,0)
 					local checkAddition=nil
+					local groupfilter=nil
 					if extrafil then
 						local ret = {extrafil(e,tp,mg1)}
 						if ret[1] then
@@ -115,6 +116,7 @@ function(fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locati
 							mg1:Merge(ret[1])
 						end
 						checkAddition=ret[2]
+						groupfilter=ret[3]
 					end
 					if gc and not mg1:Includes(gc) then
 						Fusion.ExtraGroup=nil
@@ -125,7 +127,7 @@ function(fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locati
 					Fusion.CheckExact=exactcount
 					Fusion.CheckMin=mincount
 					Fusion.CheckMax=maxcount
-					local res=Duel.IsExistingMatchingCard(Fusion.SummonEffFilter,tp,location,0,1,nil,fusfilter,e,tp,mg1,gc,chkf,value&0xffffffff,sumlimit,nosummoncheck,sumpos)
+					local res=Duel.IsExistingMatchingCard(Fusion.SummonEffFilter,tp,location,0,1,nil,fusfilter,e,tp,mg1,gc,chkf,value&0xffffffff,sumlimit,nosummoncheck,sumpos,groupfilter)
 					Fusion.CheckAdditional=nil
 					Fusion.ExtraGroup=nil
 					if not res and not sumlimit then
@@ -141,7 +143,7 @@ function(fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locati
 									if checkAddition then Fusion.CheckAdditional=aux.AND(checkAddition,fcheck) else Fusion.CheckAdditional=fcheck end
 								end
 								Fusion.ExtraGroup=mg
-								if Duel.IsExistingMatchingCard(Fusion.SummonEffFilter,tp,location,0,1,nil,aux.AND(mf,fusfilter or aux.TRUE),e,tp,mg,gc,chkf,value,sumlimit,nosummoncheck,sumpos) then
+								if Duel.IsExistingMatchingCard(Fusion.SummonEffFilter,tp,location,0,1,nil,aux.AND(mf,fusfilter or aux.TRUE),e,tp,mg,gc,chkf,value,sumlimit,nosummoncheck,sumpos,groupfilter) then
 									res=true
 									Fusion.CheckAdditional=nil
 									Fusion.ExtraGroup=nil
@@ -201,6 +203,7 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 				local checkAddition
 				local mg1=Duel.GetFusionMaterial(tp):Filter(matfilter,nil,e,tp,1)
 				local extragroup=nil
+				local groupfilter=nil
 				if extrafil then
 					local ret = {extrafil(e,tp,mg1)}
 					if ret[1] then
@@ -209,6 +212,7 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 						mg1:Merge(ret[1])
 					end
 					checkAddition=ret[2]
+					groupfilter=ret[3]
 				end
 				mg1=mg1:Filter(Card.IsCanBeFusionMaterial,nil,nil,value)
 				mg1=mg1:Filter(aux.NOT(Card.IsImmuneToEffect),nil,e)
@@ -221,7 +225,7 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 				Fusion.CheckMax=maxcount
 				Fusion.CheckAdditional=checkAddition
 				local effswithgroup={}
-				local sg1=Duel.GetMatchingGroup(Fusion.SummonEffFilter,tp,location,0,nil,fusfilter,e,tp,mg1,gc,chkf,value&0xffffffff,sumlimit,nosummoncheck,sumpos)
+				local sg1=Duel.GetMatchingGroup(Fusion.SummonEffFilter,tp,location,0,nil,fusfilter,e,tp,mg1,gc,chkf,value&0xffffffff,sumlimit,nosummoncheck,sumpos,groupfilter)
 				if #sg1>0 then
 					table.insert(effswithgroup,{e,aux.GrouptoCardid(sg1)})
 				end
@@ -241,7 +245,7 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 								if checkAddition then Fusion.CheckAdditional=aux.AND(checkAddition,fcheck) else Fusion.CheckAdditional=fcheck end
 							end
 							Fusion.ExtraGroup=mg2
-							local sg2=Duel.GetMatchingGroup(Fusion.SummonEffFilter,tp,location,0,nil,aux.AND(mf,fusfilter or aux.TRUE),e,tp,mg2,gc,chkf,value,sumlimit,nosummoncheck,sumpos)
+							local sg2=Duel.GetMatchingGroup(Fusion.SummonEffFilter,tp,location,0,nil,aux.AND(mf,fusfilter or aux.TRUE),e,tp,mg2,gc,chkf,value,sumlimit,nosummoncheck,sumpos,groupfilter)
 							if #sg2 > 0 then
 								table.insert(effswithgroup,{ce,aux.GrouptoCardid(sg2)})
 								sg1:Merge(sg2)


### PR DESCRIPTION
Updated handling for fusion materials consisting of "condition1 + conditionN + condition *N".
Add new groupfilter function to fusion spell procedure. (Should mitigate freezes for cards like invocation).