### PR TITLE
Update Synchro Monsters' scripts that specifically list a card as material

### DIFF
--- a/official/c13574687.lua
+++ b/official/c13574687.lua
@@ -1,4 +1,5 @@
 --ワンショット・キャノン
+--Turbo Cannon
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -16,6 +17,8 @@ function s.initial_effect(c)
 	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
 end
+s.material={6142213}
+s.listed_names={6142213}
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
 	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end

--- a/official/c17760003.lua
+++ b/official/c17760003.lua
@@ -20,6 +20,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 	e2:SetLabelObject(e1)
 end
+s.material={68505803}
 s.listed_names={68505803}
 function s.valcheck(e,c)
 	local g=c:GetMaterial()

--- a/official/c18013090.lua
+++ b/official/c18013090.lua
@@ -1,4 +1,5 @@
 --ニトロ・ウォリアー
+--Nitro Warrior
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -31,6 +32,7 @@ function s.initial_effect(c)
 	e3:SetOperation(s.caop)
 	c:RegisterEffect(e3)
 end
+s.material={96182448}
 s.listed_names={96182448}
 s.material_setcode=0x1017
 function s.tfilter(c,lc,stype,tp)

--- a/official/c2322421.lua
+++ b/official/c2322421.lua
@@ -16,6 +16,8 @@ function s.initial_effect(c)
 	e1:SetOperation(s.op)
 	c:RegisterEffect(e1)
 end
+s.material={71971554}
+s.listed_names={71971554}
 s.material_setcode=0x1017
 function s.tfilter(c,scard,sumtype,tp)
 	return c:IsSummonCode(scard,sumtype,tp,71971554) or c:IsHasEffect(20932152)

--- a/official/c24696097.lua
+++ b/official/c24696097.lua
@@ -56,6 +56,7 @@ function s.initial_effect(c)
 	e5:SetValue(s.valcheck)
 	c:RegisterEffect(e5)
 end
+s.material={CARD_STARDUST_DRAGON}
 s.listed_names={CARD_STARDUST_DRAGON}
 s.synchro_tuner_required=1
 s.synchro_nt_required=1

--- a/official/c25165047.lua
+++ b/official/c25165047.lua
@@ -1,4 +1,5 @@
 --ライフ・ストリーム・ドラゴン
+--Life Stream Dragon
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -39,6 +40,7 @@ function s.initial_effect(c)
 	e5:SetValue(s.valcheck)
 	c:RegisterEffect(e5)
 end
+s.material={2403771}
 s.listed_names={2403771}
 function s.lpcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsSummonType(SUMMON_TYPE_SYNCHRO)

--- a/official/c286392.lua
+++ b/official/c286392.lua
@@ -1,6 +1,5 @@
 --ジェット・ウォリアー
 --Jet Warrior
-
 local s,id=GetID()
 function s.initial_effect(c)
 	--Must be properly summoned before reviving
@@ -29,9 +28,9 @@ function s.initial_effect(c)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
 end
+s.material={9742784}
 s.listed_names={9742784}
 s.material_setcode=0x1017
-
 function s.tfilter(c,scard,sumtype,tp)
 	return c:IsSummonCode(scard,sumtype,tp,9742784) or c:IsHasEffect(20932152)
 end

--- a/official/c33972299.lua
+++ b/official/c33972299.lua
@@ -1,4 +1,5 @@
 --ジオ・ジェネクス
+--Geo Genex
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -21,6 +22,8 @@ function s.initial_effect(c)
 	e2:SetCondition(s.valcon)
 	c:RegisterEffect(e2)
 end
+s.material={68505803}
+s.listed_names={68505803}
 s.listed_series={0x2}
 function s.valcon(e)
 	return e:GetHandler():GetFlagEffect(id)~=0

--- a/official/c3429238.lua
+++ b/official/c3429238.lua
@@ -1,4 +1,5 @@
 --ドリル・ウォリアー
+--Drill Warrior
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -36,6 +37,7 @@ function s.initial_effect(c)
 	e3:SetOperation(s.spop)
 	c:RegisterEffect(e3)
 end
+s.material={56286179}
 s.material_setcode=0x1017
 function s.tfilter(c,scard,sumtype,tp)
 	return c:IsSummonCode(scard,sumtype,tp,56286179) or c:IsHasEffect(20932152)

--- a/official/c3429238.lua
+++ b/official/c3429238.lua
@@ -38,6 +38,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 s.material={56286179}
+s.listed_names={56286179}
 s.material_setcode=0x1017
 function s.tfilter(c,scard,sumtype,tp)
 	return c:IsSummonCode(scard,sumtype,tp,56286179) or c:IsHasEffect(20932152)

--- a/official/c37993923.lua
+++ b/official/c37993923.lua
@@ -30,6 +30,7 @@ function s.initial_effect(c)
 	e2:SetOperation(s.posop)
 	c:RegisterEffect(e2)
 end
+s.material={63977008}
 s.listed_names={63977008}
 s.material_setcode=0x1017
 function s.matfilter(c,scard,sumtype,tp)

--- a/official/c39823987.lua
+++ b/official/c39823987.lua
@@ -24,8 +24,8 @@ function s.initial_effect(c)
 	e2:SetOperation(s.regop)
 	c:RegisterEffect(e2)
 end
-s.material={66818682}
-s.listed_names={66818682}
+s.material={78275321}
+s.listed_names={78275321,66818682}
 function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
 end

--- a/official/c39823987.lua
+++ b/official/c39823987.lua
@@ -1,4 +1,5 @@
 --太陽龍インティ
+--Sun Dragon Inti
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -23,6 +24,7 @@ function s.initial_effect(c)
 	e2:SetOperation(s.regop)
 	c:RegisterEffect(e2)
 end
+s.material={66818682}
 s.listed_names={66818682}
 function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)

--- a/official/c42810973.lua
+++ b/official/c42810973.lua
@@ -1,4 +1,5 @@
 --ジャンク・アーチャー
+--Junk Archer
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -16,6 +17,8 @@ function s.initial_effect(c)
 	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
 end
+s.material={63977008}
+s.listed_names={63977008}
 s.material_setcode=0x1017
 function s.tfilter(c,scard,sumtype,tp)
 	return c:IsSummonCode(scard,sumtype,tp,63977008) or c:IsHasEffect(20932152)

--- a/official/c43925870.lua
+++ b/official/c43925870.lua
@@ -1,4 +1,5 @@
 --ウィンドファーム・ジェネクス
+--Windmill Genex
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -24,6 +25,8 @@ function s.initial_effect(c)
 	e2:SetOperation(s.desop)
 	c:RegisterEffect(e2)
 end
+s.material={68505803}
+s.listed_names={68505803}
 function s.val(e,c)
 	return Duel.GetMatchingGroupCount(Card.IsFacedown,0,LOCATION_SZONE,LOCATION_SZONE,nil)*300
 end

--- a/official/c45037489.lua
+++ b/official/c45037489.lua
@@ -20,6 +20,8 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 	aux.DoubleSnareValidity(c,LOCATION_MZONE)
 end
+s.material={19642774}
+s.listed_names={19642774}
 s.material_setcode=0x1017
 function s.tfilter(c,scard,sumtype,tp)
 	return c:IsSummonCode(scard,sumtype,tp,19642774) or c:IsHasEffect(20932152)

--- a/official/c46195773.lua
+++ b/official/c46195773.lua
@@ -1,4 +1,5 @@
 --ターボ・ウォリアー
+--Turbo Warrior
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -22,6 +23,8 @@ function s.initial_effect(c)
 	e2:SetValue(s.efilter)
 	c:RegisterEffect(e2)
 end
+s.material={67270095}
+s.listed_names={67270095}
 s.material_setcode=0x1017
 function s.tfilter(c,scard,sumtype,tp)
 	return c:IsSummonCode(scard,sumtype,tp,67270095) or c:IsHasEffect(20932152)

--- a/official/c47421985.lua
+++ b/official/c47421985.lua
@@ -1,4 +1,5 @@
 --ハイドロ・ジェネクス
+--Hydro Genex
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -16,6 +17,8 @@ function s.initial_effect(c)
 	e1:SetOperation(s.recop)
 	c:RegisterEffect(e1)
 end
+s.material={68505803}
+s.listed_names={68505803}
 function s.reccon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local t=Duel.GetAttackTarget()

--- a/official/c5309481.lua
+++ b/official/c5309481.lua
@@ -1,4 +1,5 @@
 --蘇りし魔王 ハ・デス
+--Revived King Ha Des
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -12,6 +13,7 @@ function s.initial_effect(c)
 	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
 end
+s.material={33420078}
 s.listed_names={33420078}
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()

--- a/official/c59771339.lua
+++ b/official/c59771339.lua
@@ -1,4 +1,5 @@
 --ジャンク・バーサーカー
+--Junk Berserker
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -26,6 +27,8 @@ function s.initial_effect(c)
 	e2:SetOperation(s.desop)
 	c:RegisterEffect(e2)
 end
+s.material={63977008}
+s.listed_names={63977008}
 s.listed_series={0x43}
 s.material_setcode=0x1017
 function s.tfilter(c,lc,stype,tp)

--- a/official/c59969392.lua
+++ b/official/c59969392.lua
@@ -1,4 +1,5 @@
 --アンデット・スカル・デーモン
+--Archfiend Zombie-Skull
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -14,3 +15,5 @@ function s.initial_effect(c)
 	e1:SetValue(1)
 	c:RegisterEffect(e1)
 end
+s.material={33420078}
+s.listed_names={33420078}

--- a/official/c6021033.lua
+++ b/official/c6021033.lua
@@ -1,4 +1,5 @@
 --デスカイザー・ドラゴン
+--Doomkaiser Dragon
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -22,6 +23,8 @@ function s.initial_effect(c)
 	e2:SetLabelObject(e1)
 	c:RegisterEffect(e2)
 end
+s.material={33420078}
+s.listed_names={33420078}
 function s.filter(c,e,tp)
 	return c:IsRace(RACE_ZOMBIE) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end

--- a/official/c60800381.lua
+++ b/official/c60800381.lua
@@ -1,4 +1,5 @@
 --ジャンク・ウォリアー
+--Junk Warrior
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -14,6 +15,8 @@ function s.initial_effect(c)
 	e1:SetOperation(s.op)
 	c:RegisterEffect(e1)
 end
+s.material={63977008}
+s.listed_names={63977008}
 s.material_setcode=0x1017
 function s.tfilter(c,lc,stype,tp)
 	return c:IsSummonCode(lc,stype,tp,63977008) or c:IsHasEffect(20932152)

--- a/official/c6588580.lua
+++ b/official/c6588580.lua
@@ -1,4 +1,5 @@
 --サーマル・ジェネクス
+--Thermal Genex
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -24,6 +25,8 @@ function s.initial_effect(c)
 	e2:SetOperation(s.damop)
 	c:RegisterEffect(e2)
 end
+s.material={68505803}
+s.listed_names={68505803}
 function s.val(e,c)
 	return Duel.GetMatchingGroupCount(Card.IsAttribute,c:GetControler(),LOCATION_GRAVE,0,nil,ATTRIBUTE_FIRE)*200
 end

--- a/official/c66818682.lua
+++ b/official/c66818682.lua
@@ -1,4 +1,5 @@
 --月影龍クイラ
+--Moon Dragon Quilla
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -25,7 +26,8 @@ function s.initial_effect(c)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
 end
-s.listed_names={39823987}
+s.material={78552773}
+s.listed_names={78552773,39823987}
 function s.rectg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local tc=Duel.GetAttacker()

--- a/official/c67030233.lua
+++ b/official/c67030233.lua
@@ -53,6 +53,7 @@ function s.initial_effect(c)
 	e5:SetValue(s.valcheck)
 	c:RegisterEffect(e5)
 end
+s.material={70902743,21159309}
 s.listed_names={70902743,21159309}
 s.synchro_nt_required=1
 function s.descon(e,tp,eg,ep,ev,re,r,rp)

--- a/official/c68319538.lua
+++ b/official/c68319538.lua
@@ -29,6 +29,7 @@ function s.initial_effect(c)
 	e2:SetOperation(s.desop)
 	c:RegisterEffect(e2)
 end
+s.material={652362}
 s.listed_series={0xc}
 s.counter_place_list={COUNTER_A}
 function s.filter(c)

--- a/official/c68319538.lua
+++ b/official/c68319538.lua
@@ -30,6 +30,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 s.material={652362}
+s.listed_names={652362}
 s.listed_series={0xc}
 s.counter_place_list={COUNTER_A}
 function s.filter(c)

--- a/official/c74860293.lua
+++ b/official/c74860293.lua
@@ -1,4 +1,5 @@
 --ジャンク・デストロイヤー
+--Junk Destroyer
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -16,6 +17,8 @@ function s.initial_effect(c)
 	e1:SetOperation(s.op)
 	c:RegisterEffect(e1)
 end
+s.material={63977008}
+s.listed_names={63977008}
 s.material_setcode=0x1017
 function s.tfilter(c,lc,stype,tp)
 	return c:IsSummonCode(lc,stype,tp,63977008) or c:IsHasEffect(20932152)

--- a/official/c7841112.lua
+++ b/official/c7841112.lua
@@ -55,6 +55,7 @@ function s.initial_effect(c)
 	e5:SetValue(s.valcheck)
 	c:RegisterEffect(e5)
 end
+s.material={21159309,CARD_STARDUST_DRAGON}
 s.listed_names={21159309,CARD_STARDUST_DRAGON}
 s.synchro_nt_required=1
 function s.negcon(e,tp,eg,ep,ev,re,r,rp)

--- a/official/c8310162.lua
+++ b/official/c8310162.lua
@@ -1,4 +1,5 @@
 --Sin パラドクス・ドラゴン
+--Malefic Paradox Dragon
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -25,7 +26,8 @@ function s.initial_effect(c)
 	e2:SetCondition(s.descon)
 	c:RegisterEffect(e2)
 end
-s.listed_names={27564031}
+s.material={74509280}
+s.listed_names={74509280,27564031}
 function s.descon(e)
 	return not Duel.IsEnvironment(27564031)
 end

--- a/official/c97489701.lua
+++ b/official/c97489701.lua
@@ -1,4 +1,5 @@
 --スカーレッド・ノヴァ・ドラゴン
+--Red Nova Dragon
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -51,6 +52,7 @@ function s.initial_effect(c)
 	e6:SetCode(21142671)
 	c:RegisterEffect(e6)
 end
+s.material={70902743}
 s.listed_names={70902743}
 s.synchro_nt_required=1
 function s.atkval(e,c)

--- a/pre-release/c100200199.lua
+++ b/pre-release/c100200199.lua
@@ -33,6 +33,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 s.material={78868119}
+s.listed_names={78868119}
 function s.tfilter(c,lc,stype,tp)
 	return c:IsSummonCode(lc,stype,tp,78868119)
 end

--- a/pre-release/c100200199.lua
+++ b/pre-release/c100200199.lua
@@ -32,6 +32,7 @@ function s.initial_effect(c)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
 end
+s.material={78868119}
 function s.tfilter(c,lc,stype,tp)
 	return c:IsSummonCode(lc,stype,tp,78868119)
 end

--- a/pre-release/c101105104.lua
+++ b/pre-release/c101105104.lua
@@ -46,6 +46,7 @@ function s.initial_effect(c)
 	e3:SetOperation(s.negop)
 	c:RegisterEffect(e3)	
 end
+s.material={21159309}
 s.listed_names={21159309,CARD_STARDUST_DRAGON}
 s.synchro_nt_required=1
 function s.cfilter(c,sc,tp)


### PR DESCRIPTION
Added the "material" metatable to them. Required for the implementation of "Synchro Overtake".