### PR TITLE
"Do X instead of 1 of those materials" fix

### DIFF
--- a/official/c35394356.lua
+++ b/official/c35394356.lua
@@ -53,12 +53,11 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 end
 	--Except turn was sent, and would detach
 function s.rcon(e,tp,eg,ep,ev,re,r,rp)
-	return aux.exccon(e)
-		and (r&REASON_COST)~=0 and re:IsActivated()
+	return aux.exccon(e) and (r&REASON_COST)~=0 and re:IsActivated()
 		and re:IsActiveType(TYPE_XYZ)
 		and e:GetHandler():IsAbleToRemoveAsCost()
 		and ep==e:GetOwnerPlayer() and ev>=1
-		and rc:GetOverlayCount()>=ev-1
+		and re:GetHandler():GetOverlayCount()>=ev-1
 end
 	--Detach substitution
 function s.rop(e,tp,eg,ep,ev,re,r,rp)

--- a/official/c35394356.lua
+++ b/official/c35394356.lua
@@ -58,6 +58,7 @@ function s.rcon(e,tp,eg,ep,ev,re,r,rp)
 		and re:IsActiveType(TYPE_XYZ)
 		and e:GetHandler():IsAbleToRemoveAsCost()
 		and ep==e:GetOwnerPlayer() and ev>=1
+		and rc:GetOverlayCount()>=ev-1
 end
 	--Detach substitution
 function s.rop(e,tp,eg,ep,ev,re,r,rp)

--- a/official/c98204536.lua
+++ b/official/c98204536.lua
@@ -59,7 +59,7 @@ function s.rcon(e,tp,eg,ep,ev,re,r,rp)
 	return (r&REASON_COST)~=0 and re:IsActivated()
 		and re:IsActiveType(TYPE_XYZ) and (rc:IsSetCard(0x70) or rc:IsSetCard(0x48))
 		and e:GetHandler():IsAbleToGraveAsCost()
-		and ep==e:GetOwnerPlayer() and ev>=1
+		and ep==e:GetOwnerPlayer() and ev>=1 and rc:GetOverlayCount()>=ev-1
 end
 function s.rop(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.SendtoGrave(e:GetHandler(),REASON_COST)

--- a/pre-release/c100278025.lua
+++ b/pre-release/c100278025.lua
@@ -90,6 +90,7 @@ function s.rcon(e,tp,eg,ep,ev,re,r,rp)
 		and re:GetHandler():GetEquipGroup():IsContains(c)
 		and c:IsAbleToGraveAsCost()
 		and ep==e:GetOwnerPlayer() and ev>=1
+		and rc:GetOverlayCount()>=ev-1
 end
 function s.rop(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.SendtoGrave(e:GetHandler(),REASON_COST)

--- a/pre-release/c100278025.lua
+++ b/pre-release/c100278025.lua
@@ -85,9 +85,10 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.rcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
+	local rc=re:GetHandler()
 	return (r&REASON_COST)~=0 and re:IsActivated()
 		and re:IsActiveType(TYPE_XYZ)
-		and re:GetHandler():GetEquipGroup():IsContains(c)
+		and rc:GetEquipGroup():IsContains(c)
 		and c:IsAbleToGraveAsCost()
 		and ep==e:GetOwnerPlayer() and ev>=1
 		and rc:GetOverlayCount()>=ev-1


### PR DESCRIPTION
They now take into account the Xyz Monster's current number of materials (e.g. if the Xyz Monster has no materials but needs to detach 2 for its effect, then this "instead" effect cannot be applied). The following cards were updated:
- Daruma Dropper
- Chronomaly Palace Trilithon
- ZW - Sylphid Wing