### PR TITLE
Fusion procedure update to handle once per turn "EFFECT_EXTRA_FUSION_MATERIAL" effects

### DIFF
--- a/official/c72064891.lua
+++ b/official/c72064891.lua
@@ -24,6 +24,7 @@ function s.initial_effect(c)
 	e2:SetCode(EFFECT_EXTRA_FUSION_MATERIAL)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetTargetRange(LOCATION_GRAVE,0)
+	e2:SetOperation(Fusion.BanishMaterial)
 	e2:SetValue(s.mtval)
 	c:RegisterEffect(e2)
 end

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -82,7 +82,13 @@ function Fusion.RegisterSummonEff(c,...)
 	Card.RegisterEffect((tab and c["handler"] or c),e1)
 	return e1
 end
-function Fusion.SummonEffFilter(c,fusfilter,e,tp,mg,gc,chkf,value,sumlimit,nosummoncheck,sumpos)
+function Fusion.SummonEffFilter(c,fusfilter,e,tp,mg,gc,chkf,value,sumlimit,nosummoncheck,sumpos,efmg)
+	if efmg and #efmg>0 then
+		efmg=efmg:Filter(GetExtraMatEff,nil,c)
+		if #efmg>0 then
+			mg:Merge(efmg)
+		end
+	end
 	return c:IsType(TYPE_FUSION) and (not fusfilter or fusfilter(c,tp)) and (nosummoncheck or c:IsCanBeSpecialSummoned(e,value,tp,sumlimit,false,sumpos))
 			and c:CheckFusionMaterial(mg,gc,chkf)
 end
@@ -115,7 +121,12 @@ function(fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locati
 				matfilter=matfilter or Card.IsAbleToGrave
 				stage2 = stage2 or aux.TRUE
 				if chk==0 then
-					local mg1=Duel.GetFusionMaterial(tp):Filter(matfilter,nil,e,tp,0)
+					
+					--FIX FLASH FUSION ATTEMPT
+					local fmg_all=Duel.GetFusionMaterial(tp)
+					local mg1=fmg_all:Filter(matfilter,nil,e,tp,0)
+					local efmg=fmg_all:Filter(GetExtraMatEff,nil)
+					
 					local checkAddition=nil
 					if extrafil then
 						local ret = {extrafil(e,tp,mg1)}
@@ -163,7 +174,7 @@ function(fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locati
 							end
 						end
 					end
-					local res=Duel.IsExistingMatchingCard(Fusion.SummonEffFilter,tp,location,0,1,nil,fusfilter,e,tp,mg1,gc,chkf,value&0xffffffff,sumlimit,nosummoncheck,sumpos)
+					local res=Duel.IsExistingMatchingCard(Fusion.SummonEffFilter,tp,location,0,1,nil,fusfilter,e,tp,mg1,gc,chkf,value&0xffffffff,sumlimit,nosummoncheck,sumpos,efmg)
 					Fusion.CheckAdditional=nil
 					Fusion.ExtraGroup=nil
 					if not res and not notfusion then
@@ -238,7 +249,12 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 				matfilter=matfilter or Card.IsAbleToGrave
 				stage2 = stage2 or aux.TRUE
 				local checkAddition
-				local mg1=Duel.GetFusionMaterial(tp):Filter(matfilter,nil,e,tp,1)
+				
+				--FIX FLASH FUSION ATTEMPT
+				local fmg_all=Duel.GetFusionMaterial(tp)
+				local mg1=fmg_all:Filter(matfilter,nil,e,tp,1)
+				local efmg=fmg_all:Filter(GetExtraMatEff,nil)
+				
 				local extragroup=nil
 				if extrafil then
 					local ret = {extrafil(e,tp,mg1)}
@@ -260,7 +276,7 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 				Fusion.CheckMax=maxcount
 				Fusion.CheckAdditional=checkAddition
 				local effswithgroup={}
-				local sg1=Duel.GetMatchingGroup(Fusion.SummonEffFilter,tp,location,0,nil,fusfilter,e,tp,mg1,gc,chkf,value&0xffffffff,sumlimit,nosummoncheck,sumpos)
+				local sg1=Duel.GetMatchingGroup(Fusion.SummonEffFilter,tp,location,0,nil,fusfilter,e,tp,mg1,gc,chkf,value&0xffffffff,sumlimit,nosummoncheck,sumpos,efmg)
 				if #sg1>0 then
 					table.insert(effswithgroup,{e,aux.GrouptoCardid(sg1)})
 				end

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -398,7 +398,7 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 								local extra_feff=GetExtraMatEff(extra_feff_mg:GetFirst(),tc)
 								if extra_feff then
 									local extra_feff_op=extra_feff:GetOperation()
-									if extra_feff and extra_feff_op then
+									if extra_feff_op then
 										extra_feff_op(e,tc,tp,extra_feff_mg)
 									else
 										Duel.SendtoGrave(extra_feff_mg,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -46,7 +46,7 @@ Debug.ReloadFieldBegin=(function()
 --If summon_card is provided, also mimic the check done internally for EFFECT_EXTRA_FUSION_MATERIAL
 --where the value is checked with the currently summoning card
 local function GetExtraMatEff(c,summon_card)
-	local effs={c:GetCardEffect(EFFECT_EXTRA_FUSION_MATERIAL)}
+	local effs={c:IsHasEffect(EFFECT_EXTRA_FUSION_MATERIAL)}
 	for _,eff in ipairs(effs) do
 		if eff~=geff then
 			if not summon_card then

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -139,7 +139,7 @@ function(fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locati
 					if #extra_feff_mg>0 then
 						local extra_feff=GetExtraMatEff(extra_feff_mg:GetFirst())
 						--Check if you need to remove materials from the pool if the flag is ON
-						if extra_feff and Duel.GetFlagEffect(tp,extra_feff:GetHandler():GetCode())>0 then
+						if extra_feff and not extra_feff:CheckCountLimit(tp) then
 							--If "extrafil" exists and it doesn't return anything in
 							--the GY (so that effects like "Dragon's Mirror" are excluded),
 							--remove all the EFFECT_EXTRA_FUSION_MATERIAL cards
@@ -307,7 +307,7 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 						local extra_feff_mg=mg1:Filter(GetExtraMatEff,nil)
 						if #extra_feff_mg>0 then
 							local extra_feff=GetExtraMatEff(extra_feff_mg:GetFirst())
-							if extra_feff and Duel.GetFlagEffect(tp,extra_feff:GetHandler():GetCode())>0 then
+							if extra_feff and not extra_feff:CheckCountLimit(tp) then
 								if extrafil then
 									local extrafil_g=extrafil(e,tp,mg1)
 									if #extrafil_g>0 and not extrafil_g:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE) then
@@ -328,13 +328,11 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 							local extra_feff=GetExtraMatEff(extra_feff_mg:GetFirst(),tc)
 							if extra_feff then
 								local extra_feff_op=extra_feff:GetOperation()
-								local extra_feff_c=extra_feff:GetHandler()
 								--If the operation of the EFFECT_EXTRA_FUSION_MATERIAL effect
 								--is different than "extraop", the flag is OFF, and the player
 								--chooses to apply the effect, then select which cards
 								--the effect will be applied for and execute the operation.
-								if extra_feff_op and extraop~=extra_feff_op
-									and Duel.GetFlagEffect(tp,extra_feff_c:GetCode())==0 then
+								if extra_feff_op and extraop~=extra_feff_op and extra_feff:CheckCountLimit(tp) then
 									local flag
 									if extrafil then
 										local extrafil_g=extrafil(e,tp,mg1)
@@ -344,7 +342,7 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 											mat1:Sub(extra_feff_mg)
 											extra_feff_op(e,tc,tp,extra_feff_mg)
 											flag=true
-										elseif #extrafil_g>=0 and Duel.SelectEffectYesNo(tp,extra_feff_c) then
+										elseif #extrafil_g>=0 and Duel.SelectEffectYesNo(tp,extra_feff:GetHandler()) then
 											--Select which cards you'll apply the
 											--EFFECT_EXTRA_FUSION_MATERIAL effect for
 											--and execute the operation.
@@ -364,9 +362,9 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 										flag=true
 									end
 									--If the EFFECT_EXTRA_FUSION_MATERIAL effect is OPT
-									--register a flag on the player with the card's ID.
-									if flag and extra_feff:GetCountLimit()>0 then
-										Duel.RegisterFlagEffect(tp,extra_feff_c:GetCode(),RESET_PHASE+PHASE_END,0,1)
+									--then "use" its count limit.
+									if flag and extra_feff:CheckCountLimit(tp) then
+										extra_feff:UseCountLimit(tp,1)
 									end
 								end
 							end
@@ -393,9 +391,9 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 									Duel.SendtoGrave(extra_feff_mg,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 								end
 								--If the EFFECT_EXTRA_FUSION_MATERIAL effect is OPT
-								--register a flag on the player with the card's ID.
-								if extra_feff:GetCountLimit()>0 then
-									Duel.RegisterFlagEffect(tp,extra_feff:GetHandler():GetCode(),RESET_PHASE+PHASE_END,0,1)
+								--then "use" its count limit.
+								if extra_feff:CheckCountLimit(tp) then
+									extra_feff:UseCountLimit(tp,1)
 								end
 							end
 						end

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -162,6 +162,7 @@ function(fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locati
 								local extrafil_g=extrafil(e,tp,mg1)
 								if #extrafil_g>0 and not extrafil_g:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE) then
 									mg1:Sub(extra_feff_mg:Filter(Card.IsLocation,nil,LOCATION_GRAVE))
+									efmg:Clear()
 								end
 							--If "extrafil" doesn't exist then remove all the
 							--EFFECT_EXTRA_FUSION_MATERIAL cards from the material group.
@@ -171,6 +172,7 @@ function(fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locati
 							--(only relevant for "Fullmetalfoes Alkahest" atm, but he's not OPT).
 							else
 								mg1:Sub(extra_feff_mg:Filter(Card.IsLocation,nil,LOCATION_GRAVE))
+								efmg:Clear()
 							end
 						end
 					end
@@ -328,9 +330,11 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 									local extrafil_g=extrafil(e,tp,mg1)
 									if #extrafil_g>0 and not extrafil_g:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE) then
 										mg1:Sub(extra_feff_mg:Filter(Card.IsLocation,nil,LOCATION_GRAVE))
+										efmg:Clear()
 									end
 								else
 									mg1:Sub(extra_feff_mg:Filter(Card.IsLocation,nil,LOCATION_GRAVE))
+									efmg:Clear()
 								end
 							end
 						end

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -315,21 +315,39 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 							--chooses to apply the effect, then select which cards
 							--the effect will be applied for and execute the operation.
 							if extra_feff and extra_feff_op and extraop~=extra_feff_op
-								and Duel.GetFlagEffect(tp,extra_feff_c:GetCode())==0
-								and Duel.SelectEffectYesNo(tp,extra_feff_c) then
+								and Duel.GetFlagEffect(tp,extra_feff_c:GetCode())==0 then
+								local flag=0
+								if extrafil then
+									local extrafil_g=extrafil(e,tp,mg1)
+									if #extrafil_g>0 and not extrafil_g:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE) then
+										--The Fusion effect by default does not use the GY
+										--so the player is forced to apply this effect.
+										mat1:Sub(extra_feff_mg)
+										extra_feff_op(e,tc,tp,extra_feff_mg)
+										flag=1
+									elseif Duel.SelectEffectYesNo(tp,extra_feff_c) then
+										--Select which cards you'll apply the
+										--EFFECT_EXTRA_FUSION_MATERIAL effect for
+										--and execute the operation.
+										Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RESOLVECARD)
+										local g=extra_feff_mg:Select(tp,1,#extra_feff_mg,nil)
+										if #g>0 then
+											mat1:Sub(g)
+											extra_feff_op(e,tc,tp,g)
+											flag=1
+										end
+									end
+								else
+									--The Fusion effect by default does not use the GY
+									--so the player is forced to apply this effect.
+									mat1:Sub(extra_feff_mg)
+									extra_feff_op(e,tc,tp,extra_feff_mg)
+									flag=1
+								end
 								--If the EFFECT_EXTRA_FUSION_MATERIAL effect is OPT
 								--register a flag on the player with the card's ID.
-								if extra_feff:GetCountLimit()>0 then
+								if flag==1 and extra_feff:GetCountLimit()>0 then
 									Duel.RegisterFlagEffect(tp,extra_feff_c:GetCode(),RESET_PHASE+PHASE_END,0,1)
-								end
-								--Select which cards you'll apply the
-								--EFFECT_EXTRA_FUSION_MATERIAL effect for
-								--and execute the operation.
-								Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RESOLVECARD)
-								local g=extra_feff_mg:Select(tp,1,#extra_feff_mg,nil)
-								if #g>0 then
-									extra_feff_op(e,tc,tp,g)
-									mat1:Sub(g)
 								end
 							end
 						end

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -396,16 +396,18 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 							end
 							if #extra_feff_mg>0 then
 								local extra_feff=GetExtraMatEff(extra_feff_mg:GetFirst(),tc)
-								local extra_feff_op=extra_feff:GetOperation()
-								if extra_feff and extra_feff_op then
-									extra_feff_op(e,tc,tp,extra_feff_mg)
-								else
-									Duel.SendtoGrave(extra_feff_mg,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
-								end
-								--If the EFFECT_EXTRA_FUSION_MATERIAL effect is OPT
-								--then "use" its count limit.
-								if extra_feff:CheckCountLimit(tp) then
-									extra_feff:UseCountLimit(tp,1)
+								if extra_feff then
+									local extra_feff_op=extra_feff:GetOperation()
+									if extra_feff and extra_feff_op then
+										extra_feff_op(e,tc,tp,extra_feff_mg)
+									else
+										Duel.SendtoGrave(extra_feff_mg,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+									end
+									--If the EFFECT_EXTRA_FUSION_MATERIAL effect is OPT
+									--then "use" its count limit.
+									if extra_feff:CheckCountLimit(tp) then
+										extra_feff:UseCountLimit(tp,1)
+									end
 								end
 							end
 						end

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -391,23 +391,22 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 							--EFFECT_EXTRA_FUSION_MATERIAL effect, if it exists.
 							--If it doesn't exist then send the materials to the GY.
 							local extra_feff_mg,normal_mg=mat1:Split(GetExtraMatEff,nil,tc)
+							local extra_feff
+							if #extra_feff_mg>0 then extra_feff=GetExtraMatEff(extra_feff_mg:GetFirst(),tc) end
 							if #normal_mg>0 then
 								Duel.SendtoGrave(normal_mg,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 							end
-							if #extra_feff_mg>0 then
-								local extra_feff=GetExtraMatEff(extra_feff_mg:GetFirst(),tc)
-								if extra_feff then
-									local extra_feff_op=extra_feff:GetOperation()
-									if extra_feff_op then
-										extra_feff_op(e,tc,tp,extra_feff_mg)
-									else
-										Duel.SendtoGrave(extra_feff_mg,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
-									end
-									--If the EFFECT_EXTRA_FUSION_MATERIAL effect is OPT
-									--then "use" its count limit.
-									if extra_feff:CheckCountLimit(tp) then
-										extra_feff:UseCountLimit(tp,1)
-									end
+							if extra_feff then
+								local extra_feff_op=extra_feff:GetOperation()
+								if extra_feff_op then
+									extra_feff_op(e,tc,tp,extra_feff_mg)
+								else
+									Duel.SendtoGrave(extra_feff_mg,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+								end
+								--If the EFFECT_EXTRA_FUSION_MATERIAL effect is OPT
+								--then "use" its count limit.
+								if extra_feff:CheckCountLimit(tp) then
+									extra_feff:UseCountLimit(tp,1)
 								end
 							end
 						end

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -319,13 +319,13 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 								local flag=0
 								if extrafil then
 									local extrafil_g=extrafil(e,tp,mg1)
-									if #extrafil_g>0 and not extrafil_g:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE) then
+									if #extrafil_g>=0 and not extrafil_g:IsExists(Card.IsLocation,1,nil,LOCATION_GRAVE) then
 										--The Fusion effect by default does not use the GY
 										--so the player is forced to apply this effect.
 										mat1:Sub(extra_feff_mg)
 										extra_feff_op(e,tc,tp,extra_feff_mg)
 										flag=1
-									elseif Duel.SelectEffectYesNo(tp,extra_feff_c) then
+									elseif #extrafil_g>=0 and Duel.SelectEffectYesNo(tp,extra_feff_c) then
 										--Select which cards you'll apply the
 										--EFFECT_EXTRA_FUSION_MATERIAL effect for
 										--and execute the operation.


### PR DESCRIPTION
Current known problems:
- Assumes that the effect with the OPT limit lets you use cards in the GY (getting the effect's `TargetRange` is impossible at the moment, but if it becomes possible in the future it could be used to determine which location you're checking).
- No way to tell (that I could find) if a Fusion Summoning effect can use the whole field or just the Monster Zones, so an effect like that of `Fullmetalfoes Alkahest` but once per turn is not currently handled (not an issue yet with the current card pool).
- Currently does not support multiple different `EFFECT_EXTRA_FUSION_MATERIAL` effects at the same time. Although this could be remedied, there is no Fusion Monster that overlaps between any 2 of them at the moment since `Cyberdark Chimera` locks you into using only Dragon or Machine "Cyber" monsters as Fusion Material (the 3 official cards with such an effect being `Fullmetalfoes Alkahest`, `Curse of Dragon, the Magical Knight Dragon`, and `Cyberdark Chimera`).

Changes required in the `EFFECT_EXTRA_FUSION_MATERIAL` effects:
- If they have a specific operation that is performed on the Fusion Materials, add it as a generic operation function to them (example in `Curse of Dragon, the Magical Knight Dragon` here:
https://github.com/ProjectIgnis/CardScripts/pull/602/files#diff-6f83ef671374be763fb6229936689d2632d4cb02167c442e1edbd6c2dd7cc588).
- If the effect can only be applied once per turn, add a `SetCountLimit` to the `EFFECT_EXTRA_FUSION_MATERIAL` effect.

Example puzzle with `Curse of Dragon, the Magical Knight Dragon` where you can test various different scenarios below.
<details>
<summary><code>Curse of Dragon, the Magical Knight Dragon</code> puzzle:</summary>

```lua
--Created using senpaizuri's Puzzle Maker (updated by Naim & Larry126)
--Partially rewritten by edo9300
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,5)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

--Main Deck (yours)
Debug.AddCard(28279543,0,0,LOCATION_DECK,0,POS_FACEDOWN)

--Extra Deck (yours)
Debug.AddCard(66889139,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
Debug.AddCard(66889139,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)
Debug.AddCard(66889139,0,0,LOCATION_EXTRA,0,POS_FACEDOWN)

--Hand (yours)
Debug.AddCard(28279543,0,0,LOCATION_HAND,0,POS_FACEDOWN)
Debug.AddCard(6368038,0,0,LOCATION_HAND,0,POS_FACEDOWN)

--GY (yours)
Debug.AddCard(6368038,0,0,LOCATION_GRAVE,0,POS_FACEUP)
Debug.AddCard(6368038,0,0,LOCATION_GRAVE,0,POS_FACEUP)
Debug.AddCard(28279543,0,0,LOCATION_GRAVE,0,POS_FACEUP)
Debug.AddCard(28279543,0,0,LOCATION_GRAVE,0,POS_FACEUP)

--Monster Zones (yours)
Debug.AddCard(72064891,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK,true)

--Spell & Trap Zones (yours)
Debug.AddCard(24094653,0,0,LOCATION_SZONE,0,POS_FACEDOWN)
Debug.AddCard(24094653,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
--Debug.AddCard(71490127,0,0,LOCATION_SZONE,1,POS_FACEDOWN)
Debug.AddCard(81223446,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
Debug.AddCard(14087893,0,0,LOCATION_SZONE,3,POS_FACEDOWN)
Debug.AddCard(81223446,0,0,LOCATION_SZONE,4,POS_FACEDOWN)

Debug.ReloadFieldEnd()
--aux.BeginPuzzle()
```
</details>