### PR TITLE
Effect Resets + Hardcode removal for "Hundred-Eyes Dragon"s

### DIFF
--- a/unofficial/c100000150.lua
+++ b/unofficial/c100000150.lua
@@ -1,4 +1,5 @@
 --ワンハンドレッド·アイ·ドラゴン
+--Hundred Eyes Dragon (VG)
 local s,id=GetID()
 function s.initial_effect(c)
 	c:AddSetcodesRule(0x601)
@@ -6,78 +7,36 @@ function s.initial_effect(c)
 	c:EnableReviveLimit()
 	Synchro.AddDarkSynchroProcedure(c,Synchro.NonTuner(nil),nil,8)
 	--copy
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e2:SetCode(EVENT_ADJUST)
-	e2:SetRange(LOCATION_MZONE)
-	e2:SetOperation(s.operation)
-	c:RegisterEffect(e2)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_ADJUST)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetOperation(s.operation)
+	c:RegisterEffect(e1)
 	--search
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(id,1))
-	e3:SetType(EFFECT_TYPE_TRIGGER_F+EFFECT_TYPE_SINGLE)
-	e3:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
-	e3:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
-	e3:SetCode(EVENT_DESTROYED)
-	e3:SetTarget(s.thtg)
-	e3:SetOperation(s.thop)
-	c:RegisterEffect(e3)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetType(EFFECT_TYPE_TRIGGER_F+EFFECT_TYPE_SINGLE)
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e2:SetCode(EVENT_DESTROYED)
+	e2:SetTarget(s.thtg)
+	e2:SetOperation(s.thop)
+	c:RegisterEffect(e2)
 	--actlimit
-	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
-	e4:SetCode(EVENT_ATTACK_ANNOUNCE)
-	e4:SetOperation(s.atkop)
-	c:RegisterEffect(e4)
-	--Randomizer
-	local e6=Effect.CreateEffect(c)
-	e6:SetDescription(aux.Stringid(13582837,0))
-	e6:SetCategory(CATEGORY_DRAW+CATEGORY_DAMAGE)
-	e6:SetType(EFFECT_TYPE_IGNITION)
-	e6:SetCountLimit(1)
-	e6:SetLabel(13582837)
-	e6:SetRange(LOCATION_MZONE)
-	e6:SetCondition(s.con)
-	e6:SetTarget(s.rndtg)
-	e6:SetOperation(s.rndop)
-	c:RegisterEffect(e6)
-	--Necromancer
-	local e7=Effect.CreateEffect(c)
-	e7:SetDescription(aux.Stringid(56209279,1))
-	e7:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e7:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e7:SetType(EFFECT_TYPE_IGNITION)
-	e7:SetCountLimit(1)
-	e7:SetRange(LOCATION_MZONE)
-	e7:SetLabel(56209279)
-	e7:SetCondition(s.con)
-	e7:SetTarget(s.necrotg)
-	e7:SetOperation(s.necroop)
-	c:RegisterEffect(e7)
-	--Doom Dragon
-	local e8=Effect.CreateEffect(c)
-	e8:SetType(EFFECT_TYPE_IGNITION)
-	e8:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e8:SetCategory(CATEGORY_DAMAGE+CATEGORY_DESTROY)
-	e8:SetDescription(aux.Stringid(72896720,0))
-	e8:SetCountLimit(1)
-	e8:SetRange(LOCATION_MZONE)
-	e8:SetLabel(72896720)
-	e8:SetCondition(s.con)
-	e8:SetCost(s.ddcost)
-	e8:SetTarget(s.ddtg)
-	e8:SetOperation(s.ddop)
-	c:RegisterEffect(e8)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e3:SetOperation(s.atkop)
+	c:RegisterEffect(e3)
 end
 s.listed_series={0xb}
 function s.filter(c)
-	return c:IsSetCard(0xb) and c:IsType(TYPE_MONSTER)
+	return c:IsSetCard(0xb) and c:IsMonster()
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_GRAVE,0,nil)
-	g:Remove(s.codefilter,nil,13582837)
-	g:Remove(s.codefilter,nil,56209279)
-	g:Remove(s.codefilter,nil,72896720)
 	g:Remove(s.codefilterchk,nil,e:GetHandler())
 	if c:IsFacedown() or #g<=0 then return end
 	repeat
@@ -143,76 +102,4 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.aclimit(e,re,tp)
 	return re:IsHasType(EFFECT_TYPE_ACTIVATE)
-end
-function s.con(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)==0 and not e:GetHandler():IsDisabled() 
-		and Duel.IsExistingMatchingCard(s.codefilter,tp,LOCATION_GRAVE,0,1,nil,e:GetLabel())
-end
-function s.rndtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
-	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,1,tp,1)
-end
-function s.rndop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)~=0 
-		or not Duel.IsExistingMatchingCard(s.codefilter,tp,LOCATION_GRAVE,0,1,nil,e:GetLabel()) then return end
-	local g=Duel.GetDecktopGroup(tp,1)
-	local tc=g:GetFirst()
-	Duel.Draw(tp,1,REASON_EFFECT)
-	if tc then
-		Duel.ConfirmCards(1-tp,tc)
-		Duel.BreakEffect()
-		if tc:IsType(TYPE_MONSTER) then
-			Duel.Damage(1-tp,tc:GetLevel()*200,REASON_EFFECT)
-		else
-			Duel.Damage(tp,500,REASON_EFFECT)
-		end
-		Duel.ShuffleHand(tp)
-	end
-end
-function s.necrofilter(c,e,tp)
-	return c:IsSetCard(0xb) and c:GetCode()~=56209279 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-end
-function s.necrotg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and s.necrofilter(chkc,e,tp) end
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingTarget(s.necrofilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectTarget(tp,s.necrofilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
-end
-function s.necroop(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsExistingMatchingCard(s.codefilter,tp,LOCATION_GRAVE,0,1,nil,e:GetLabel()) then return end
-	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
-	end
-end
-function s.ddcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():GetAttackAnnouncedCount()==0 end
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_SINGLE)
-	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_OATH)
-	e1:SetCode(EFFECT_CANNOT_ATTACK)
-	e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-	e:GetHandler():RegisterEffect(e1,true)
-end
-function s.ddtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) end
-	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,0,LOCATION_MZONE,1,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_MZONE,1,1,nil)
-	local d=g:GetFirst()
-	local atk=0
-	if d:IsFaceup() then atk=d:GetAttack() end
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,atk/2)
-end
-function s.ddop(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
-		local atk=0
-		if tc:IsFaceup() then atk=tc:GetAttack() end
-		if Duel.Destroy(tc,REASON_EFFECT)==0 then return end
-		Duel.Damage(1-tp,atk/2,REASON_EFFECT)
-	end
 end

--- a/unofficial/c513000004.lua
+++ b/unofficial/c513000004.lua
@@ -15,43 +15,72 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 	--search
 	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(135598,0))
+	e3:SetDescription(aux.Stringid(id,1))
 	e3:SetType(EFFECT_TYPE_TRIGGER_F+EFFECT_TYPE_SINGLE)
 	e3:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
-	e3:SetCode(EVENT_TO_GRAVE)
+	e3:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e3:SetCode(EVENT_DESTROYED)
 	e3:SetCondition(s.thcon)
 	e3:SetTarget(s.thtg)
 	e3:SetOperation(s.thop)
 	c:RegisterEffect(e3)
 end
 function s.filter(c)
-	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_MONSTER)
+	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsMonster()
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local wg=Duel.GetMatchingGroup(s.filter,c:GetControler(),LOCATION_GRAVE,0,nil)
-	local wbc=wg:GetFirst()
-	while wbc do
-		local code=wbc:GetOriginalCode()
-		if c:IsFaceup() and c:GetFlagEffect(code)==0 then
-			c:CopyEffect(code,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,1)
-			c:RegisterFlagEffect(code,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
-		end
-		wbc=wg:GetNext()
+	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_GRAVE,0,nil)
+	g:Remove(s.codefilterchk,nil,e:GetHandler())
+	if c:IsFacedown() or #g<=0 then return end
+	repeat
+		local tc=g:GetFirst()
+		local code=tc:GetOriginalCode()
+		local cid=c:CopyEffect(code,RESET_EVENT+RESETS_STANDARD,1)
+		c:RegisterFlagEffect(code,RESET_EVENT+RESETS_STANDARD,0,0)
+		local e0=Effect.CreateEffect(c)
+		e0:SetCode(id)
+		e0:SetLabel(code)
+		e0:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e0,true)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_ADJUST)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetLabel(cid)
+		e1:SetLabelObject(e0)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetOperation(s.resetop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		c:RegisterEffect(e1,true)
+		g:Remove(s.codefilter,nil,code)
+	until #g<=0
+end
+function s.codefilter(c,code)
+	return c:IsOriginalCode(code) and c:IsSetCard(0xb)
+end
+function s.codefilterchk(c,sc)
+	return sc:GetFlagEffect(c:GetOriginalCode())>0
+end
+function s.resetop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_GRAVE,0,nil)
+	if not g:IsExists(s.codefilter,1,nil,e:GetLabelObject():GetLabel()) or c:IsDisabled() then
+		c:ResetEffect(e:GetLabel(),RESET_COPY)
+		c:ResetFlagEffect(e:GetLabelObject():GetLabel())
 	end
 end
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsReason(REASON_DESTROY)
+	return e:GetHandler():IsLocation(LOCATION_GRAVE)
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,0,LOCATION_DECK)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToHand,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToHand,tp,LOCATION_DECK,0,1,1,nil)
 	if #g>0 then
 		Duel.SendtoHand(g,nil,REASON_EFFECT)
-		Duel.ConfirmCards(1-tp,g)
 	end
 end

--- a/unofficial/c513000004.lua
+++ b/unofficial/c513000004.lua
@@ -57,7 +57,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	until #g<=0
 end
 function s.codefilter(c,code)
-	return c:IsOriginalCode(code) and c:IsSetCard(0xb)
+	return c:IsOriginalCode(code) and c:IsAttribute(ATTRIBUTE_DARK)
 end
 function s.codefilterchk(c,sc)
 	return sc:GetFlagEffect(c:GetOriginalCode())>0


### PR DESCRIPTION
They now reset the copied effects correctly. More elaborately: The way it was before didn't reset any effects the moment a monster leaves the GY. Therefore, I adapted the procedure of the VG version and just got rid of the hardcodes since they're not needed and function properly when just copied.
The test puzzle if needed to convince yourself:

Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN+DUEL_SIMPLE_AI,5)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

--GY (yours)
Debug.AddCard(511000625,0,0,LOCATION_GRAVE,0,POS_FACEUP)
Debug.AddCard(13582837,0,0,LOCATION_GRAVE,0,POS_FACEUP)
Debug.AddCard(56209279,0,0,LOCATION_GRAVE,0,POS_FACEUP)

--Monster Zones (yours)
--Debug.AddCard(100000150,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)
Debug.AddCard(513000004,0,0,LOCATION_MZONE,2,POS_FACEUP_ATTACK,true)

--Spell & Trap Zones (yours)
Debug.AddCard(83764718,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
Debug.AddCard(83764718,0,0,LOCATION_DECK,0,POS_FACEDOWN)

Debug.ReloadFieldEnd()

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).