### PR TITLE
Unofficial Scripts Fixes

### DIFF
--- a/unofficial/c511009136.lua
+++ b/unofficial/c511009136.lua
@@ -60,7 +60,7 @@ function s.valcheck(e,c)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=e:GetHandler():GetOverlayCount()
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,ct,REASON_COST) end
+	if chk==0 then return ct>0 and e:GetHandler():CheckRemoveOverlayCard(tp,ct,REASON_COST) end
 	e:GetHandler():RemoveOverlayCard(tp,ct,ct,REASON_COST)
 end
 function s.filter(c)

--- a/unofficial/c511009300.lua
+++ b/unofficial/c511009300.lua
@@ -141,7 +141,7 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 		local e1=Effect.CreateEffect(tc)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_BATTLE)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		e1:SetValue(atk)
 		tc:RegisterEffect(e1)
 	end

--- a/unofficial/c700000018.lua
+++ b/unofficial/c700000018.lua
@@ -1,5 +1,5 @@
---Scripted by Eerie Code
 --Abyss Script - Fantasy Magic
+--Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -11,8 +11,9 @@ function s.initial_effect(c)
 	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
 end
+s.listed_series={0x10ec}
 function s.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x120e)
+	return c:IsFaceup() and c:IsSetCard(0x10ec)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and s.filter(chkc) end
@@ -25,7 +26,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(c)
-		e1:SetDescription(aux.Stringid(2356994,0))
+		e1:SetDescription(aux.Stringid(id,0))
 		e1:SetCategory(CATEGORY_TOHAND)
 		e1:SetProperty(EFFECT_FLAG_CLIENT_HINT)
 		e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)

--- a/unofficial/c810000096.lua
+++ b/unofficial/c810000096.lua
@@ -29,7 +29,7 @@ function s.initial_effect(c)
 	e3:SetOperation(s.thchk)
 	c:RegisterEffect(e3)
 	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e4:SetCode(EVENT_PHASE+PHASE_END)
 	e4:SetRange(LOCATION_SZONE)
 	e4:SetCountLimit(1)
@@ -65,13 +65,12 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function s.thchk(e,tp,eg,ep,ev,re,r,rp)
-	if not (Duel.GetTurnPlayer()==tp) or Duel.GetCurrentPhase()~=PHASE_END then return end
 	if eg:IsExists(s.cfilter,1,nil) then
 		e:GetHandler():RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
 	end
 end
 function s.mtcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():GetFlagEffect(id)==0
+	return Duel.GetTurnPlayer()==tp and e:GetHandler():GetFlagEffect(id)==0
 end
 function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsRelateToEffect(e) then Duel.Destroy(e:GetHandler(),REASON_EFFECT) end


### PR DESCRIPTION
"Abyss Script - Fantasy Magic (Anime)": Was using an old setcode.
"Yosen Whirlwind (Anime)": The destruction effect should be mandatory and in your turn.
"Gladiator Beast Andabata (Anime)": The atk boost should last even after battle phase.
"Neo Galaxy-Eyes Cipher Dragon (Anime)": Was not checking if there are available materials to detach.