### PR TITLE
Fix "Leraje the God of Archery"

### DIFF
--- a/official/c49922726.lua
+++ b/official/c49922726.lua
@@ -42,7 +42,7 @@ end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() and chkc~=c end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,c) end
+	if chk==0 then return c:GetAttack()>0 and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,c) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,c)
 end


### PR DESCRIPTION
Can't use the 2nd effect if its ATK is 0.

<!--
Hello, thanks for submitting a pull request! Please provide enough information so we can review it.

If you are submitting an addition to the unofficial script project, the pull request title should be
of the form `Add "CARD NAME"`. Replace this comment with a Yugipedia link.

If you are submitting a bug fix, the pull request title should be of the form `Fix "CARD NAME"`.
In this case, replace this comment with a brief summary of your change. What did you fix?
--->

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
