### PR TITLE
Small addition to the Synchro Proc

### DIFF
--- a/proc_synchro.lua
+++ b/proc_synchro.lua
@@ -5,10 +5,17 @@ end
 if not Synchro then
 	Synchro = aux.SynchroProcedure
 end
-function Synchro.NonTuner(f,a,b,c)
-	return	function(target,scard,sumtype,tp)
-				return target:IsNotTuner(scard,tp) and (not f or f(target,a,b,c))
-			end
+function Synchro.Tuner(f,...)
+	local params={...}
+	return function(target,scard,sumtype,tp)
+		return target:IsType(TYPE_TUNER,scard,sumtype,tp) and (not f or f(target,table.unpack(params)))
+	end
+end
+function Synchro.NonTuner(f,...)
+	local params={...}
+	return function(target,scard,sumtype,tp)
+		return target:IsNotTuner(scard,tp) and (not f or f(target,table.unpack(params)))
+	end
 end
 function Synchro.NonTunerEx(f,val)
 	return	function(target,scard,sumtype,tp)

--- a/proc_synchro.lua
+++ b/proc_synchro.lua
@@ -8,7 +8,7 @@ end
 function Synchro.Tuner(f,...)
 	local params={...}
 	return function(target,scard,sumtype,tp)
-		return target:IsType(TYPE_TUNER,scard,sumtype,tp) and (not f or f(target,table.unpack(params)))
+		return not target:IsNotTuner(scard,tp) and (not f or f(target,table.unpack(params)))
 	end
 end
 function Synchro.NonTuner(f,...)


### PR DESCRIPTION
Synchro.NonTuner only accepted 3 extra parameters. This change allows for an indefinite amount of them.
Moreover, Synchro.Tuner doesn't exist for whatever reason, so I created the counterpart to Synchro.NonTuner.
- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).