### PR TITLE
Add Card.CanSummonOrSet and Duel.SummonOrSet

### DIFF
--- a/official/c19041767.lua
+++ b/official/c19041767.lua
@@ -1,4 +1,5 @@
 --デュアル・サモナー
+--Gemini Summoner
 local s,id=GetID()
 function s.initial_effect(c)
 	--battle indes
@@ -28,7 +29,7 @@ function s.valcon(e,re,r,rp)
 	return (r&REASON_BATTLE)~=0
 end
 function s.filter(c)
-	return c:IsType(TYPE_GEMINI) and (c:IsSummonable(true,nil) or c:IsMSetable(true,nil))
+	return c:IsType(TYPE_GEMINI) and c:CanSummonOrSet(true,nil)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=Duel.GetTurnPlayer()
@@ -43,15 +44,8 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
-	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil)
-	local tc=g:GetFirst()
+	local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil):GetFirst()
 	if tc then
-		local s1=tc:IsSummonable(true,nil)
-		local s2=tc:IsMSetable(true,nil)
-		if (s1 and s2 and Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)==POS_FACEUP_ATTACK) or not s2 then
-			Duel.Summon(tp,tc,true,nil)
-		else
-			Duel.MSet(tp,tc,true,nil)
-		end
+		Duel.SummonOrSet(tp,tc,true,nil)
 	end
 end

--- a/official/c39712330.lua
+++ b/official/c39712330.lua
@@ -1,12 +1,11 @@
 --決戦の火蓋
+--Cry Havoc!
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetTarget(s.target)
 	c:RegisterEffect(e1)
 	--instant
 	local e2=Effect.CreateEffect(c)
@@ -15,63 +14,44 @@ function s.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCode(EVENT_FREE_CHAIN)
-	e2:SetCondition(s.con)
+	e2:SetCondition(s.condition)
 	e2:SetCost(s.cost)
-	e2:SetTarget(s.tg)
-	e2:SetOperation(s.op)
+	e2:SetTarget(s.target)
+	e2:SetOperation(s.activate)
 	c:RegisterEffect(e2)
+end
+function s.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsTurnPlayer(tp) and Duel.IsMainPhase()
 end
 function s.cfilter(c)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c)
 end
 function s.filter(c)
-	return c:IsType(TYPE_NORMAL) and (c:IsSummonable(true,nil) or c:IsMSetable(true,nil))
-end
-function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	if s.con(e,tp,eg,ep,ev,re,r,rp) and s.cost(e,tp,eg,ep,ev,re,r,rp,0) 
-		and Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_HAND,0,nil)>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
-		s.cost(e,tp,eg,ep,ev,re,r,rp,1)
-		e:SetOperation(s.op)
-		Duel.SetOperationInfo(0,CATEGORY_SUMMON,nil,1,0,0)
-	else
-		e:SetOperation(nil)
-	end
-end
-function s.con(e,tp,eg,ep,ev,re,r,rp)
-	local tn=Duel.GetTurnPlayer()
-	local ph=Duel.GetCurrentPhase()
-	return tn==tp and (ph==PHASE_MAIN1 or ph==PHASE_MAIN2)
+	return c:IsType(TYPE_NORMAL) and c:CanSummonOrSet(true,nil)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil) end
+	if e:GetHandler():GetFlagEffect(id)==0 then
+		e:GetHandler():RegisterFlagEffect(id,RESET_CHAIN,0,1,Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil))
+	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 	local g=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,1,nil)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
-function s.tg(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		if not e:GetHandler():IsStatus(STATUS_CHAINING) then
-			local ct=Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_HAND,0,nil)
-			e:SetLabel(ct)
-			return ct>0
-		else return e:GetLabel()>0 end
+		if e:GetHandler():GetFlagEffect(id)==0 then
+			return Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil)>0
+		else return e:GetHandler():GetFlagEffectLabel(id)>0 end
 	end
-	e:SetLabel(e:GetLabel()-1)
+	e:GetHandler():SetFlagEffectLabel(id,e:GetHandler():GetFlagEffectLabel(id)-1)
 	Duel.SetOperationInfo(0,CATEGORY_SUMMON,nil,1,0,0)
 end
-function s.op(e,tp,eg,ep,ev,re,r,rp)
+function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
-	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND,0,1,1,nil)
-	local tc=g:GetFirst()
+	local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND,0,1,1,nil):GetFirst()
 	if tc then
-		local s1=tc:IsSummonable(true,nil)
-		local s2=tc:IsMSetable(true,nil)
-		if (s1 and s2 and Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)==POS_FACEUP_ATTACK) or not s2 then
-			Duel.Summon(tp,tc,true,nil)
-		else
-			Duel.MSet(tp,tc,true,nil)
-		end
+		Duel.SummonOrSet(tp,tc,true,nil)
 	end
 end

--- a/official/c75025112.lua
+++ b/official/c75025112.lua
@@ -1,5 +1,5 @@
 --魍魎跋扈
---Revenants Running Rampant
+--Free-Range Monsters
 --Scripted by Hel
 local s,id=GetID()
 function s.initial_effect(c)
@@ -16,24 +16,14 @@ end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsMainPhase()
 end
-function s.filter(c)
-	return c:IsSummonable(true,nil) or c:IsMSetable(true,nil)
-end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.CanSummonOrSet,tp,LOCATION_HAND+LOCATION_MZONE,0,1,nil,true,nil) end
 	Duel.SetOperationInfo(0,CATEGORY_SUMMON,nil,1,0,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
-	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil)
-	local tc=g:GetFirst()
+	local tc=Duel.SelectMatchingCard(tp,Card.CanSummonOrSet,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil,true,nil):GetFirst()
 	if tc then
-		local s1=tc:IsSummonable(true,nil)
-		local s2=tc:IsMSetable(true,nil)
-		if (s1 and s2 and Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)==POS_FACEUP_ATTACK) or not s2 then
-			Duel.Summon(tp,tc,true,nil)
-		else
-			Duel.MSet(tp,tc,true,nil)
-		end
+		Duel.SummonOrSet(tp,tc,true,nil)
 	end
 end

--- a/official/c80604091.lua
+++ b/official/c80604091.lua
@@ -20,9 +20,6 @@ function s.initial_effect(c)
 	e2:SetOperation(s.activate)
 	c:RegisterEffect(e2)
 end
-function s.filter(c)
-	return c:IsSummonable(true,nil) or c:IsMSetable(true,nil)
-end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	local tn=Duel.GetTurnPlayer()
 	return (tn==tp and Duel.IsMainPhase()) or (tn~=tp and Duel.IsBattlePhase())
@@ -30,14 +27,14 @@ end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,500) end
 	if e:GetHandler():GetFlagEffect(id)==0 then
-		e:GetHandler():RegisterFlagEffect(id,RESET_CHAIN,0,1,Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil))
+		e:GetHandler():RegisterFlagEffect(id,RESET_CHAIN,0,1,Duel.GetMatchingGroupCount(Card.CanSummonOrSet,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,true,nil))
 	end
 	Duel.PayLPCost(tp,500)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		if e:GetHandler():GetFlagEffect(id)==0 then
-			return Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil)>0
+			return Duel.GetMatchingGroupCount(Card.CanSummonOrSet,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,true,nil)>0
 		else return e:GetHandler():GetFlagEffectLabel(id)>0 end
 	end
 	e:GetHandler():SetFlagEffectLabel(id,e:GetHandler():GetFlagEffectLabel(id)-1)
@@ -46,15 +43,8 @@ end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
-	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil)
-	local tc=g:GetFirst()
+	local tc=Duel.SelectMatchingCard(tp,Card.CanSummonOrSet,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil,true,nil):GetFirst()
 	if tc then
-		local s1=tc:IsSummonable(true,nil)
-		local s2=tc:IsMSetable(true,nil)
-		if (s1 and s2 and Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)==POS_FACEUP_ATTACK) or not s2 then
-			Duel.Summon(tp,tc,true,nil)
-		else
-			Duel.MSet(tp,tc,true,nil)
-		end
+		Duel.SummonOrSet(tp,tc,true,nil)
 	end
 end

--- a/official/c80921533.lua
+++ b/official/c80921533.lua
@@ -1,4 +1,5 @@
 --死皇帝の陵墓
+--Mausoleum of the Emperor
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -27,7 +28,7 @@ end
 function s.filter(c,se)
 	if not c:IsSummonableCard() then return false end
 	local mi,ma=c:GetTributeRequirement()
-	return mi>0 and (c:IsSummonable(false,se) or c:IsMSetable(false,se))
+	return mi>0 and c:CanSummonOrSet(false,se)
 end
 function s.get_targets(se,tp)
 	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_HAND,0,nil,se)
@@ -62,7 +63,7 @@ end
 function s.sfilter(c,se,ct)
 	if not c:IsSummonableCard() then return false end
 	local mi,ma=c:GetTributeRequirement()
-	return (mi==ct or ma==ct) and (c:IsSummonable(false,se) or c:IsMSetable(false,se))
+	return (mi==ct or ma==ct) and c:CanSummonOrSet(false,se)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
@@ -70,15 +71,8 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local ct=e:GetLabel()
 	local se=e:GetLabelObject()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
-	local g=Duel.SelectMatchingCard(tp,s.sfilter,tp,LOCATION_HAND,0,1,1,nil,se,ct)
-	local tc=g:GetFirst()
+	local tc=Duel.SelectMatchingCard(tp,s.sfilter,tp,LOCATION_HAND,0,1,1,nil,se,ct):GetFirst()
 	if tc then
-		local s1=tc:IsSummonable(false,se)
-		local s2=tc:IsMSetable(false,se)
-		if (s1 and s2 and Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)==POS_FACEUP_ATTACK) or not s2 then
-			Duel.Summon(tp,tc,false,se)
-		else
-			Duel.MSet(tp,tc,false,se)
-		end
+		Duel.SummonOrSet(tp,tc,false,se)
 	end
 end

--- a/official/c91957038.lua
+++ b/official/c91957038.lua
@@ -1,5 +1,5 @@
 --妖精の伝姫
---Fairy Tail
+--Fairy Tail Tales
 --Logical Nonsense and DyXel
 
 --Substitute ID
@@ -37,7 +37,7 @@ function s.initial_effect(c)
 end
 	--Check for a spellcaster with 1850 ATK with different name to Normal Summon
 function s.nsfilter(c,tp)
-	return c:IsAttack(1850) and c:IsRace(RACE_SPELLCASTER) and c:IsSummonable(true,nil) and not c:IsPublic() and
+	return c:IsAttack(1850) and c:IsRace(RACE_SPELLCASTER) and c:CanSummonOrSet(true,nil) and not c:IsPublic() and
 	       not Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsCode,c:GetCode()),tp,LOCATION_MZONE,0,1,nil)
 end
 	--Reveal a monster that fits filter's requirements as cost
@@ -60,13 +60,7 @@ function s.nsop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
-		local s1=tc:IsSummonable(true,nil)
-		local s2=tc:IsMSetable(true,nil)
-		if (s1 and s2 and Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)==POS_FACEUP_ATTACK) or not s2 then
-			Duel.Summon(tp,tc,true,nil)
-		else
-			Duel.MSet(tp,tc,true,nil)
-		end
+		Duel.SummonOrSet(tp,tc,true,nil)
 	end
 end
 	--Check for a spellcaster with 1850 ATK

--- a/pre-errata/c511003023.lua
+++ b/pre-errata/c511003023.lua
@@ -41,15 +41,8 @@ end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
-	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil)
-	local tc=g:GetFirst()
+	local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil):GetFirst()
 	if tc then
-		local s1=tc:IsSummonable(true,nil)
-		local s2=tc:IsMSetable(true,nil)
-		if (s1 and s2 and Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)==POS_FACEUP_ATTACK) or not s2 then
-			Duel.Summon(tp,tc,true,nil)
-		else
-			Duel.MSet(tp,tc,true,nil)
-		end
+		Duel.SummonOrSet(tp,tc,true,nil)
 	end
 end

--- a/unofficial/c100000078.lua
+++ b/unofficial/c100000078.lua
@@ -20,15 +20,8 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
-	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil)
-	local tc=g:GetFirst()
+	local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,1,nil):GetFirst()
 	if tc then
-		local s1=tc:IsSummonable(true,nil)
-		local s2=tc:IsMSetable(true,nil)
-		if (s1 and s2 and Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)==POS_FACEUP_ATTACK) or not s2 then
-			Duel.Summon(tp,tc,true,nil)
-		else
-			Duel.MSet(tp,tc,true,nil)
-		end
+		Duel.SummonOrSet(tp,tc,true,nil)
 	end
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1459,6 +1459,19 @@ end
 function Auxiliary.thoeSend(card)
 	return Duel.SendtoGrave(card,REASON_EFFECT)
 end
+--Helper functions to use with cards that normal summon or set a monster
+function Card.CanSummonOrSet(...)
+	return Card.IsSummonable(...) or Card.IsMSetable(...)
+end
+function Duel.SummonOrSet(tp,...)
+	local s1=Card.IsSummonable(...)
+	local s2=Card.IsMSetable(...)
+	if (s1 and s2 and Duel.SelectPosition(tp,(...),POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)==POS_FACEUP_ATTACK) or not s2 then
+		Duel.Summon(tp,...)
+	else
+		Duel.MSet(tp,...)
+	end
+end
 --[[
 Function to simplify registering EFFECT_FLAG_CLIENT_HINT to players
 -card: card that creates the hintmsg;


### PR DESCRIPTION
Simplifies scripts that can Normal Summon or Set monsters making them only use a single function instead of repeating the same checks every time.