### PR TITLE
Update counter traps that respond to summons

### DIFF
--- a/official/c11593137.lua
+++ b/official/c11593137.lua
@@ -1,4 +1,5 @@
 --混沌の落とし穴
+--Chaos Trap Hole
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -22,7 +23,7 @@ function s.filter(c)
 	return c:IsAttribute(0x30) and c:IsAbleToRemove()
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and eg:IsExists(s.filter,1,nil)
+	return Duel.GetCurrentChain(true)==0 and eg:IsExists(s.filter,1,nil)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,2000) end

--- a/official/c1637760.lua
+++ b/official/c1637760.lua
@@ -13,8 +13,8 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and Duel.GetTurnPlayer()~=tp and rp~=tp
-		and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
+	return rp~=tp and Duel.GetCurrentChain(true)==0 and Duel.IsTurnPlayer(1-tp)
+		and Duel.IsMainPhase()
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDraw(1-tp,1) end

--- a/official/c1637760.lua
+++ b/official/c1637760.lua
@@ -13,7 +13,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return rp~=tp and Duel.GetCurrentChain(true)==0 and Duel.IsTurnPlayer(1-tp)
+	return ep==1-tp and Duel.GetCurrentChain(true)==0 and Duel.IsTurnPlayer(1-tp)
 		and Duel.IsMainPhase()
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/official/c2572890.lua
+++ b/official/c2572890.lua
@@ -34,7 +34,7 @@ function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(g,REASON_COST)
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/official/c30888983.lua
+++ b/official/c30888983.lua
@@ -1,4 +1,5 @@
 --方舟の選別
+--The Selection
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -25,7 +26,7 @@ function s.filter(c)
 	return Duel.IsExistingMatchingCard(s.cfilter,0,LOCATION_MZONE,LOCATION_MZONE,1,nil,c:GetRace())
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and eg:IsExists(s.filter,1,nil)
+	return Duel.GetCurrentChain(true)==0 and eg:IsExists(s.filter,1,nil)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,1000) end

--- a/official/c32233746.lua
+++ b/official/c32233746.lua
@@ -1,4 +1,5 @@
 --ライト・バニッシュ
+--Vanquishing Light
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -19,7 +20,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,Card.IsSetCard,1,nil,0x38) end

--- a/official/c40605147.lua
+++ b/official/c40605147.lua
@@ -43,7 +43,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/official/c41420027.lua
+++ b/official/c41420027.lua
@@ -1,4 +1,5 @@
 --神の宣告
+--Solemn Judgment
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -29,7 +30,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.cost1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/official/c43340443.lua
+++ b/official/c43340443.lua
@@ -1,4 +1,5 @@
 --キックバック
+--Forced Back
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -15,7 +16,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/official/c44901281.lua
+++ b/official/c44901281.lua
@@ -1,4 +1,5 @@
 --セイバー・ホール
+--Saber Hole
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -22,8 +23,7 @@ function s.filter(c)
 	return c:IsFaceup() and c:IsSetCard(0x100d)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil)
-		and Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0 and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/official/c50323155.lua
+++ b/official/c50323155.lua
@@ -1,4 +1,5 @@
 --昇天の黒角笛
+--Black Horn of Heaven
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -12,7 +13,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=ep and #eg==1 and Duel.GetCurrentChain()==0
+	return ep==1-tp and #eg==1 and Duel.GetCurrentChain(true)==0
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/official/c56993276.lua
+++ b/official/c56993276.lua
@@ -1,4 +1,5 @@
 --エレキャンセル
+--Wattcancel
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -17,7 +18,7 @@ function s.initial_effect(c)
 end
 s.listed_series={0xe}
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and eg:IsExists(Card.IsControler,1,nil,1-tp)
+	return Duel.GetCurrentChain(true)==0 and eg:IsExists(Card.IsControler,1,nil,1-tp)
 end
 function s.cfilter(c)
 	return c:IsSetCard(0xe) and c:IsType(TYPE_MONSTER) and c:IsDiscardable()

--- a/official/c57355219.lua
+++ b/official/c57355219.lua
@@ -1,4 +1,5 @@
 --パラドックス・フュージョン
+--Paradox Fusion
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -23,7 +24,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.cfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_FUSION) and c:IsAbleToRemoveAsCost() and not c:IsStatus(STATUS_BATTLE_DESTROYED)

--- a/official/c59718521.lua
+++ b/official/c59718521.lua
@@ -1,4 +1,5 @@
 --ブローニング・パワー
+--Mind Over Matter
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -26,7 +27,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.filter(c)
 	return c:IsRace(RACE_PSYCHIC) and not c:IsStatus(STATUS_BATTLE_DESTROYED)

--- a/official/c61459246.lua
+++ b/official/c61459246.lua
@@ -44,7 +44,7 @@ function s.activate1(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.condition2(e,tp,eg,ep,ev,re,r,rp)
-	return ep==1-tp and Duel.GetCurrentChain()==0
+	return ep==1-tp and Duel.GetCurrentChain(true)==0
 		and Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsCode,CARD_DREAM_MIRROR_TERROR),tp,LOCATION_FZONE,LOCATION_FZONE,1,nil)
 end
 function s.target2(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/official/c68477598.lua
+++ b/official/c68477598.lua
@@ -1,4 +1,5 @@
 --ペンデュラム・ホール
+--Pendulum Hole
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -15,7 +16,7 @@ function s.cfilter(c)
 	return c:IsSummonType(SUMMON_TYPE_PENDULUM)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and eg:IsExists(s.cfilter,1,nil)
+	return Duel.GetCurrentChain(true)==0 and eg:IsExists(s.cfilter,1,nil)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/official/c77610503.lua
+++ b/official/c77610503.lua
@@ -15,7 +15,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=ep and Duel.GetCurrentChain()==0
+	return ep==1-tp and Duel.GetCurrentChain(true)==0
 		and Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsSummonType,SUMMON_TYPE_TRIBUTE),tp,LOCATION_MZONE,0,1,nil)
 		and not Duel.IsExistingMatchingCard(Card.IsSummonType,tp,LOCATION_MZONE,0,1,nil,SUMMON_TYPE_SPECIAL)
 end

--- a/official/c7811875.lua
+++ b/official/c7811875.lua
@@ -20,7 +20,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and ep==1-tp --tp~=ep
+	return Duel.GetCurrentChain(true)==0 and ep==1-tp
 end
 function s.cfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_SYNCHRO) and c:IsAbleToGraveAsCost()

--- a/official/c82382815.lua
+++ b/official/c82382815.lua
@@ -1,4 +1,5 @@
 --王者の看破
+--Champion's Vigilance
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -30,7 +31,7 @@ function s.cfilter(c)
 	return c:IsFaceup() and c:IsLevelAbove(7) and c:IsType(TYPE_NORMAL)
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil)
+	return Duel.GetCurrentChain(true)==0 and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function s.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/official/c84749824.lua
+++ b/official/c84749824.lua
@@ -1,4 +1,5 @@
 --神の警告
+--Solemn Warning
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -30,7 +31,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.cost1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,2000)

--- a/official/c84965420.lua
+++ b/official/c84965420.lua
@@ -19,7 +19,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and eg:IsExists(Card.IsSummonPlayer,1,nil,1-tp)
+	return Duel.GetCurrentChain(true)==0 and eg:IsExists(Card.IsSummonPlayer,1,nil,1-tp)
 		and Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsRitualMonster),tp,LOCATION_MZONE,0,1,nil)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/official/c91078716.lua
+++ b/official/c91078716.lua
@@ -1,4 +1,5 @@
 --ポリノシス
+--Pollinosis
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -26,7 +27,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.filter(c)
 	return c:IsRace(RACE_PLANT) and not c:IsStatus(STATUS_BATTLE_DESTROYED)

--- a/official/c92512625.lua
+++ b/official/c92512625.lua
@@ -1,4 +1,5 @@
 --神の忠告
+--
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -32,7 +33,7 @@ function s.cfilter(c)
 	return c:IsFacedown() and c:GetSequence()<5
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 		and not Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_SZONE,0,1,e:GetHandler())
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/official/c94662235.lua
+++ b/official/c94662235.lua
@@ -1,4 +1,5 @@
 --運命湾曲
+--Bending Destiny
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -23,11 +24,11 @@ end
 s.listed_series={0x31}
 function s.check(tp)
 	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,0,nil)
-	return g:IsExists(aux.FilterFaceupFunction(Card.IsSetCard,0x31),1,nil)
-		and not g:IsExists(aux.NOT(aux.FilterFaceupFunction(Card.IsSetCard,0x31)),1,nil)
+	local count=#g
+	return count>0 and g:FilterCount(Card.IsSetCard,nil,0x31)==count
 end
 function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and s.check(tp)
+	return Duel.GetCurrentChain(true)==0 and s.check(tp)
 end
 function s.target1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return eg:GetFirst():IsAbleToRemove() end

--- a/official/c98069388.lua
+++ b/official/c98069388.lua
@@ -1,4 +1,5 @@
 --昇天の角笛
+--Horn of Heaven
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate(summon)
@@ -19,7 +20,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0
+	return Duel.GetCurrentChain(true)==0
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroupCost(tp,aux.TRUE,1,false,nil,nil) end

--- a/unofficial/c511001666.lua
+++ b/unofficial/c511001666.lua
@@ -16,7 +16,7 @@ function s.cfilter(c)
 	return c:GetSequence()<5
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return ep==1-tp and #eg==1 and Duel.GetCurrentChain()==0 and eg:GetFirst():GetSummonType()==SUMMON_TYPE_XYZ
+	return ep==1-tp and #eg==1 and Duel.GetCurrentChain(true)==0 and eg:GetFirst():GetSummonType()==SUMMON_TYPE_XYZ
 		and not Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_ONFIELD,0,1,e:GetHandler())
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/unofficial/c511002274.lua
+++ b/unofficial/c511002274.lua
@@ -15,7 +15,7 @@ function s.initial_effect(c)
 end
 s.listed_names={68722455}
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and rp~=tp
+	return Duel.GetCurrentChain(true)==0 and ep==1-tp
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end

--- a/unofficial/c511002457.lua
+++ b/unofficial/c511002457.lua
@@ -22,7 +22,7 @@ function s.filter(c,lv)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetFieldGroup(tp,LOCATION_MZONE,0)
-	return Duel.GetCurrentChain()==0 and eg:IsExists(Card.IsControler,1,nil,1-tp) and #g==3 
+	return Duel.GetCurrentChain(true)==0 and eg:IsExists(Card.IsControler,1,nil,1-tp) and #g==3 
 		and g:IsExists(s.filter,1,nil,1) and g:IsExists(s.filter,1,nil,2) and g:IsExists(s.filter,1,nil,3)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/unofficial/c511005637.lua
+++ b/unofficial/c511005637.lua
@@ -26,7 +26,7 @@ function s.filter(c)
 	return Duel.IsExistingMatchingCard(s.cfilter,0,LOCATION_MZONE,LOCATION_MZONE,1,nil,c:GetRace())
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetCurrentChain()==0 and eg:IsExists(s.filter,1,nil)
+	return Duel.GetCurrentChain(true)==0 and eg:IsExists(s.filter,1,nil)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,0) end

--- a/unofficial/c95000027.lua
+++ b/unofficial/c95000027.lua
@@ -13,7 +13,7 @@ function s.initial_effect(c)
 end
 s.mark=2
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp~=ep and #eg==1 and Duel.GetCurrentChain()==0 
+	return ep==1-tp and #eg==1 and Duel.GetCurrentChain(true)==0 
 		and not Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_ONFIELD,0,1,e:GetHandler())
 end
 function s.filter(c,e,tp)


### PR DESCRIPTION
Update their way of checking the current chain to account for cards copying their effects, before the cards copying them would call their conditions in the target, and this would return false as Duel.GetCurrentChain would have returned a chain count of 1. Use the new parameter to make it return the proper count when being checked in the cost/target.