### PR TITLE
Update cards that can Special Summon monsters both faceup and facedown

### DIFF
--- a/goat/c504700095.lua
+++ b/goat/c504700095.lua
@@ -30,8 +30,7 @@ function s.flipop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.filter(c,e,tp)
-	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
@@ -50,24 +49,13 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	end
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local sg=g:Filter(Card.IsRelateToEffect,nil,e)
+	local sg=Duel.GetTargetCards(e)
 	if #sg==0 then return end
-	local tc=sg:GetFirst()
-	if tc and Duel.GetLocationCount(tc:GetControler(),LOCATION_MZONE)>0 then
-		local sp=tc:GetControler()
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,sp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,sp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 then Duel.SpecialSummonStep(tc,0,sp,sp,false,false,spos) end
-	end
-	tc=sg:GetNext()
-	if tc and Duel.GetLocationCount(tc:GetControler(),LOCATION_MZONE)>0 then
-		local sp=tc:GetControler()
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,sp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,sp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 then Duel.SpecialSummonStep(tc,0,sp,sp,false,false,spos) end
+	for tc in sg:Iter() do
+		if Duel.GetLocationCount(tc:GetControler(),LOCATION_MZONE)>0 then
+			local sp=tc:GetControler()
+			Duel.SpecialSummonStep(tc,0,sp,sp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
+		end
 	end
 	Duel.SpecialSummonComplete()
 end

--- a/official/c109401.lua
+++ b/official/c109401.lua
@@ -53,10 +53,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp,chk)
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) then return end
-	local pos=0
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) then pos=pos+POS_FACEUP_DEFENSE end
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then pos=pos+POS_FACEDOWN_DEFENSE end
-	if Duel.SpecialSummon(tc,0,tp,tp,false,false,pos)>0 and tc:IsFacedown() then
+	if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_DEFENSE)>0 and tc:IsFacedown() then
 		Duel.ConfirmCards(1-tp,tc)
 	end
 end

--- a/official/c16719140.lua
+++ b/official/c16719140.lua
@@ -1,4 +1,5 @@
 --サブテラーの戦士
+--Subterror Nemesis Warrior
 local s,id=GetID()
 function s.initial_effect(c)
 	--special summon
@@ -34,7 +35,7 @@ function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.costfilter(c,e,tp,mg,rlv)
 	if not (c:HasLevel() and c:IsSetCard(0xed) and c:IsType(TYPE_MONSTER) and c:IsAbleToGraveAsCost()
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN))) then return false end
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_DEFENSE)) then return false end
 	local lv=c:GetLevel()-rlv
 	return #mg>0 and (lv<=0 or mg:CheckWithSumGreater(Card.GetOriginalLevel,lv))
 end
@@ -66,10 +67,7 @@ function s.spop1(e,tp,eg,ep,ev,re,r,rp)
 	if not mg:IsContains(c) then return end
 	mg:RemoveCard(c)
 	if #mg==0 then return end
-	local spos=0
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false) then spos=spos+POS_FACEUP_DEFENSE end
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN) then spos=spos+POS_FACEDOWN_DEFENSE end
-	if spos~=0 then
+	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_DEFENSE) then
 		local lv=tc:GetLevel()-c:GetOriginalLevel()
 		local g=Group.CreateGroup()
 		if lv<=0 then
@@ -81,7 +79,7 @@ function s.spop1(e,tp,eg,ep,ev,re,r,rp)
 		end
 		g:AddCard(c)
 		if #g>=2 and Duel.Release(g,REASON_EFFECT)~=0 then
-			Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
+			Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_DEFENSE)
 		end
 	end
 end

--- a/official/c21663205.lua
+++ b/official/c21663205.lua
@@ -1,6 +1,5 @@
 --墓守の神職
 --Gravekeeper's Priest
---
 local s,id=GetID()
 function s.initial_effect(c)
 	--spsummon
@@ -28,8 +27,7 @@ function s.initial_effect(c)
 end
 s.listed_series={0x2e}
 function s.filter(c,e,tp)
-	return c:IsSetCard(0x2e) and c:IsLevel(4) and (c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+	return c:IsSetCard(0x2e) and c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
@@ -41,11 +39,8 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 then Duel.SpecialSummon(tc,0,tp,tp,false,false,spos) end
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 	end
 end
 

--- a/official/c23912837.lua
+++ b/official/c23912837.lua
@@ -26,7 +26,7 @@ function s.initial_effect(c)
 end
 s.listed_series={0x9d}
 function s.filter(c,e,tp)
-	return c:IsSetCard(0x9d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE|POS_FACEDOWN_DEFENSE)
+	return c:IsSetCard(0x9d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_DEFENSE)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
@@ -39,7 +39,7 @@ end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
-		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE|POS_FACEDOWN_DEFENSE)~=0 then
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_DEFENSE)~=0 then
 			if tc:IsFacedown() then
 				Duel.ConfirmCards(1-tp,tc)
 			end

--- a/official/c23912837.lua
+++ b/official/c23912837.lua
@@ -26,7 +26,7 @@ function s.initial_effect(c)
 end
 s.listed_series={0x9d}
 function s.filter(c,e,tp)
-	return c:IsSetCard(0x9d) and (c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+	return c:IsSetCard(0x9d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
@@ -38,11 +38,8 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) then spos=spos+POS_FACEUP_DEFENSE end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 and Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)~=0 then
+	if tc and tc:IsRelateToEffect(e) then
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 then
 			if tc:IsFacedown() then
 				Duel.ConfirmCards(1-tp,tc)
 			end

--- a/official/c23912837.lua
+++ b/official/c23912837.lua
@@ -26,7 +26,7 @@ function s.initial_effect(c)
 end
 s.listed_series={0x9d}
 function s.filter(c,e,tp)
-	return c:IsSetCard(0x9d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
+	return c:IsSetCard(0x9d) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE|POS_FACEDOWN_DEFENSE)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
@@ -39,7 +39,7 @@ end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then
-		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 then
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE|POS_FACEDOWN_DEFENSE)~=0 then
 			if tc:IsFacedown() then
 				Duel.ConfirmCards(1-tp,tc)
 			end

--- a/official/c24096499.lua
+++ b/official/c24096499.lua
@@ -1,4 +1,5 @@
 --森の聖獣 ヴァレリフォーン
+--Valerifawn, Mystical Beast of the Forest
 local s,id=GetID()
 function s.initial_effect(c)
 	--special summon
@@ -21,7 +22,7 @@ function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.filter(c,e,tp)
 	return c:IsLevelBelow(2) and c:IsRace(RACE_BEAST) and not c:IsCode(id)
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
@@ -34,10 +35,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp,chk)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 then Duel.SpecialSummon(tc,0,tp,tp,false,false,spos) end
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 	end
 end

--- a/official/c34124316.lua
+++ b/official/c34124316.lua
@@ -1,4 +1,5 @@
 --サイバーポッド
+--Cyber Jar
 local s,id=GetID()
 function s.initial_effect(c)
 	--flip
@@ -13,55 +14,42 @@ function s.initial_effect(c)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local g=Duel.GetFieldGroup(tp,LOCATION_MZONE,LOCATION_MZONE)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
 end
 function s.spchk(c,e,tp)
-	return (c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) 
-		or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local g=Duel.GetFieldGroup(tp,LOCATION_MZONE,LOCATION_MZONE)
 	Duel.Destroy(g,REASON_EFFECT)
 	Duel.BreakEffect()
 	local p=Duel.GetTurnPlayer()
 	local g1=Duel.GetDecktopGroup(p,5)
 	local g2=Duel.GetDecktopGroup(1-p,5)
-	local spg=g1:Clone()
-	spg:Merge(g2)
 	local hg=Group.CreateGroup()
 	local gg=Group.CreateGroup()
 	Duel.ConfirmDecktop(p,5)
-	local tc=g1:GetFirst()
-	for tc in aux.Next(g1) do
-		local lv=tc:GetLevel()
-		local pos=0
-		if s.spchk(tc,e,tc:GetControler()) and Duel.IsPlayerAffectedByEffect(tc:GetControler(),CARD_BLUEEYES_SPIRIT) then
+	for tc in g1:Iter() do
+		if s.spchk(tc,e,p) and Duel.IsPlayerAffectedByEffect(p,CARD_BLUEEYES_SPIRIT) then
 			gg:AddCard(tc)
 		else
-			if tc:IsCanBeSpecialSummoned(e,0,p,false,false,POS_FACEUP_ATTACK) then pos=pos+POS_FACEUP_ATTACK end
-			if tc:IsCanBeSpecialSummoned(e,0,p,false,false,POS_FACEDOWN_DEFENSE) then pos=pos+POS_FACEDOWN_DEFENSE end
-			if lv>0 and lv<=4 and pos~=0 then
+			if tc:IsLevelBelow(4) and tc:IsCanBeSpecialSummoned(e,0,p,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE) then
 				Duel.DisableShuffleCheck()
-				Duel.SpecialSummonStep(tc,0,p,p,false,false,pos)
+				Duel.SpecialSummonStep(tc,0,p,p,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 			elseif tc:IsAbleToHand() then
 				hg:AddCard(tc)
 			else gg:AddCard(tc) end
 		end
 	end
 	Duel.ConfirmDecktop(1-p,5)
-	tc=g2:GetFirst()
-	for tc in aux.Next(g2) do
-		local lv=tc:GetLevel()
-		local pos=0
-		if s.spchk(tc,e,tc:GetControler()) and Duel.IsPlayerAffectedByEffect(tc:GetControler(),CARD_BLUEEYES_SPIRIT) then
+	for tc in g2:Iter() do
+		if s.spchk(tc,e,1-p) and Duel.IsPlayerAffectedByEffect(1-p,CARD_BLUEEYES_SPIRIT) then
 			gg:AddCard(tc)
 		else
-			if tc:IsCanBeSpecialSummoned(e,0,1-p,false,false,POS_FACEUP_ATTACK) then pos=pos+POS_FACEUP_ATTACK end
-			if tc:IsCanBeSpecialSummoned(e,0,1-p,false,false,POS_FACEDOWN_DEFENSE) then pos=pos+POS_FACEDOWN_DEFENSE end
-			if lv>0 and lv<=4 and pos~=0 then
+			if tc:IsLevelBelow(4) and tc:IsCanBeSpecialSummoned(e,0,1-p,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE) then
 				Duel.DisableShuffleCheck()
-				Duel.SpecialSummonStep(tc,0,1-p,1-p,false,false,pos)
+				Duel.SpecialSummonStep(tc,0,1-p,1-p,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 			elseif tc:IsAbleToHand() then
 				hg:AddCard(tc)
 			else gg:AddCard(tc) end

--- a/official/c34124316.lua
+++ b/official/c34124316.lua
@@ -1,5 +1,6 @@
 --サイバーポッド
 --Cyber Jar
+--Scripted by edo9300
 local s,id=GetID()
 function s.initial_effect(c)
 	--flip
@@ -18,53 +19,60 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
 end
 function s.spchk(c,e,tp)
-	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
+	return c:IsLevelBelow(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
+end
+local function summon(g,e,p,tograve,ft)
+	if #g==0 then return end
+	if ft==0 then
+		tograve:Merge(g)
+		return
+	end
+	if ft<#g then
+		Duel.Hint(HINT_SELECTMSG,p,HINTMSG_SPSUMMON)
+		local newg=g:Select(p,ft,ft,nil)
+		tograve:Merge(g:Sub(newg))
+		g=newg
+	end
+	for tc in g:Iter() do
+		Duel.SpecialSummonStep(tc,0,p,p,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
+	end
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetFieldGroup(tp,LOCATION_MZONE,LOCATION_MZONE)
 	Duel.Destroy(g,REASON_EFFECT)
 	Duel.BreakEffect()
 	local p=Duel.GetTurnPlayer()
-	local g1=Duel.GetDecktopGroup(p,5)
-	local g2=Duel.GetDecktopGroup(1-p,5)
-	local hg=Group.CreateGroup()
-	local gg=Group.CreateGroup()
+	local summonable1,nonsummonable1=Duel.GetDecktopGroup(p,5):Split(s.spchk,nil,e,p)
+	local summonable2,nonsummonable2=Duel.GetDecktopGroup(1-p,5):Split(s.spchk,nil,e,p)
+	
+	local ft1=Duel.GetLocationCount(p,LOCATION_MZONE)
+	if ft1>1 and Duel.IsPlayerAffectedByEffect(p,CARD_BLUEEYES_SPIRIT) and #summonable1>1 then
+		nonsummonable1:Merge(summonable1)
+		summonable1:Clear()
+	end
+	local ft2=Duel.GetLocationCount(1-p,LOCATION_MZONE)
+	if ft2>1 and Duel.IsPlayerAffectedByEffect(1-p,CARD_BLUEEYES_SPIRIT) and #summonable2>1 then
+		nonsummonable2:Merge(summonable2)
+		summonable2:Clear()
+	end
+	
+	local tohand,tograve=nonsummonable1:Merge(nonsummonable2):Split(Card.IsAbleToHand,nil)
+	
+	Duel.DisableShuffleCheck()
+	
 	Duel.ConfirmDecktop(p,5)
-	for tc in g1:Iter() do
-		if s.spchk(tc,e,p) and Duel.IsPlayerAffectedByEffect(p,CARD_BLUEEYES_SPIRIT) then
-			gg:AddCard(tc)
-		else
-			if tc:IsLevelBelow(4) and tc:IsCanBeSpecialSummoned(e,0,p,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE) then
-				Duel.DisableShuffleCheck()
-				Duel.SpecialSummonStep(tc,0,p,p,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
-			elseif tc:IsAbleToHand() then
-				hg:AddCard(tc)
-			else gg:AddCard(tc) end
-		end
-	end
+	summon(summonable1,e,p,tograve,ft1)
+	
 	Duel.ConfirmDecktop(1-p,5)
-	for tc in g2:Iter() do
-		if s.spchk(tc,e,1-p) and Duel.IsPlayerAffectedByEffect(1-p,CARD_BLUEEYES_SPIRIT) then
-			gg:AddCard(tc)
-		else
-			if tc:IsLevelBelow(4) and tc:IsCanBeSpecialSummoned(e,0,1-p,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE) then
-				Duel.DisableShuffleCheck()
-				Duel.SpecialSummonStep(tc,0,1-p,1-p,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
-			elseif tc:IsAbleToHand() then
-				hg:AddCard(tc)
-			else gg:AddCard(tc) end
-		end
-	end
+	summon(summonable2,e,1-p,tograve,ft2)
 	Duel.SpecialSummonComplete()
-	if #hg>0 then
-		Duel.DisableShuffleCheck()
-		Duel.SendtoHand(hg,nil,REASON_EFFECT)
+	if #tohand>0 then
+		Duel.SendtoHand(tohand,nil,REASON_EFFECT)
 		Duel.ShuffleHand(tp)
 		Duel.ShuffleHand(1-tp)
 	end
-	if #gg>0 then
-		Duel.DisableShuffleCheck()
-		Duel.SendtoGrave(gg,REASON_EFFECT)
+	if #tograve>0 then
+		Duel.SendtoGrave(tograve,REASON_EFFECT)
 	end
 	local fg=Duel.GetMatchingGroup(Card.IsFacedown,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	Duel.ShuffleSetCard(fg)

--- a/official/c39432962.lua
+++ b/official/c39432962.lua
@@ -1,4 +1,5 @@
 --ドドドウィッチ
+--Dododo Witch
 local s,id=GetID()
 function s.initial_effect(c)
 	--spsummon
@@ -18,7 +19,7 @@ end
 s.listed_series={0x82}
 function s.filter(c,e,tp)
 	return c:IsSetCard(0x82) and c:GetCode()~=id
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -30,11 +31,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
-	if tc then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
+	if tc and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 then
 		if tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end

--- a/official/c39581190.lua
+++ b/official/c39581190.lua
@@ -51,7 +51,7 @@ function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsReason(REASON_DESTROY) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(0xed) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE|POS_FACEDOWN_DEFENSE)
+	return c:IsSetCard(0xed) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -64,7 +64,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
 	if not tc then return end
-	if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE|POS_FACEDOWN_DEFENSE)~=0 then
+	if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_DEFENSE)~=0 then
 		if tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end

--- a/official/c39581190.lua
+++ b/official/c39581190.lua
@@ -51,7 +51,7 @@ function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsReason(REASON_DESTROY) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(0xed) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
+	return c:IsSetCard(0xed) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -64,7 +64,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
 	if not tc then return end
-	if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 then
+	if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE|POS_FACEDOWN_DEFENSE)~=0 then
 		if tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end

--- a/official/c39581190.lua
+++ b/official/c39581190.lua
@@ -51,7 +51,7 @@ function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsReason(REASON_DESTROY) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(0xed) and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+	return c:IsSetCard(0xed) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -64,11 +64,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
 	if not tc then return end
-	local spos=0
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) then spos=spos+POS_FACEUP_DEFENSE end
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-	if spos~=0 then
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
+	if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 then
 		if tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end

--- a/official/c42143067.lua
+++ b/official/c42143067.lua
@@ -1,4 +1,5 @@
 --怒気土器
+--Doki Doki
 local s,id=GetID()
 function s.initial_effect(c)
 	--special summon
@@ -22,8 +23,8 @@ function s.cfilter(c,e,tp)
 		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp,c:GetOriginalAttribute(),c:GetOriginalLevel())
 end
 function s.spfilter(c,e,tp,att,lv)
-	return c:IsRace(RACE_ROCK) and c:GetOriginalAttribute()==att and c:GetOriginalLevel()==lv
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+	return c:IsRace(RACE_ROCK) and c:IsOriginalAttribute(att) and c:GetOriginalLevel()==lv
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
@@ -44,11 +45,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp,gc:GetOriginalAttribute(),gc:GetOriginalLevel())
 	local tc=g:GetFirst()
-	if tc then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
+	if tc and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 then
 		if tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end

--- a/official/c44311445.lua
+++ b/official/c44311445.lua
@@ -1,4 +1,5 @@
 --マドルチェ・プディンセス・ショコ・ア・ラ・モード
+--Madolche Puddingcess Chocolat-a-la-Mode
 local s,id=GetID()
 function s.initial_effect(c)
 	--xyz summon
@@ -61,7 +62,7 @@ function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	c:RegisterFlagEffect(id,RESET_CHAIN,0,1)
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(0x71) and (c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+	return c:IsSetCard(0x71) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -73,11 +74,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
-	if tc then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
+	if tc and  Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 then
 		if tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end

--- a/official/c50766506.lua
+++ b/official/c50766506.lua
@@ -27,7 +27,7 @@ function s.cfilter(c,e,tp,ft)
 end
 function s.spfilter(c,lv,e,tp)
 	return c:IsLevelBelow(lv) and c:IsSetCard(0x2b) and
-		(c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+		c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
@@ -58,12 +58,8 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	sg:Remove(Card.IsLevelAbove,nil,slv+1)
 	if #sg==0 then return end
 	local cg=aux.SelectUnselectGroup(sg,e,tp,1,ft,s.rescon(slv),1,tp,HINTMSG_SPSUMMON)
-	for tc in aux.Next(cg) do
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		Duel.SpecialSummonStep(tc,0,tp,tp,false,false,spos)
-		if tc:IsFacedown() then
+	for tc in cg:Iter() do
+		if Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 and tc:IsFacedown() then
 			cg:AddCard(tc)
 		end
 		c:SetCardTarget(tc)

--- a/official/c51205763.lua
+++ b/official/c51205763.lua
@@ -28,7 +28,7 @@ end
 s.listed_series={0x104}
 s.listed_names={id}
 function s.filter(c,e,tp)
-	return c:IsSetCard(0x104) and not c:IsCode(id) and (c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+	return c:IsSetCard(0x104) and not c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -41,10 +41,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.filter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
 	if not tc then return end
-	local spos=0
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-	if spos~=0 and Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)~=0 then
+	if spos~=0 and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 then
 		if tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end

--- a/official/c58551308.lua
+++ b/official/c58551308.lua
@@ -26,8 +26,7 @@ function s.flipop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.filter(c,e,tp)
-	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
@@ -46,24 +45,13 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	end
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	local sg=g:Filter(Card.IsRelateToEffect,nil,e)
+	local sg=Duel.GetTargetCards(e)
 	if #sg==0 then return end
-	local tc=sg:GetFirst()
-	if tc and Duel.GetLocationCount(tc:GetControler(),LOCATION_MZONE)>0 then
-		local sp=tc:GetControler()
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,sp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,sp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 then Duel.SpecialSummonStep(tc,0,sp,sp,false,false,spos) end
-	end
-	tc=sg:GetNext()
-	if tc and Duel.GetLocationCount(tc:GetControler(),LOCATION_MZONE)>0 then
-		local sp=tc:GetControler()
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,sp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,sp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 then Duel.SpecialSummonStep(tc,0,sp,sp,false,false,spos) end
+	for tc in sg:Iter() do
+		if Duel.GetLocationCount(tc:GetControler(),LOCATION_MZONE)>0 then
+			local sp=tc:GetControler()
+			Duel.SpecialSummonStep(tc,0,sp,sp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
+		end
 	end
 	Duel.SpecialSummonComplete()
 end

--- a/official/c58911105.lua
+++ b/official/c58911105.lua
@@ -1,4 +1,5 @@
 --成金忍者
+--Upstart Golden Ninja
 local s,id=GetID()
 function s.initial_effect(c)
 	--to hand
@@ -25,7 +26,7 @@ function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.filter(c,e,tp)
 	return c:IsLevelBelow(4) and c:IsSetCard(0x2b) and
-		(c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+		c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_DEFENSE)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -38,11 +39,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
 	if not tc then return end
-	local spos=0
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) then spos=spos+POS_FACEUP_DEFENSE end
-	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-	Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
-	if tc:IsFacedown() then
+	if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_DEFENSE)~=0 and tc:IsFacedown() then
 		Duel.ConfirmCards(1-tp,tc)
 	end
 end

--- a/official/c64749612.lua
+++ b/official/c64749612.lua
@@ -21,7 +21,7 @@ end
 s.listed_series={0x2b}
 function s.spfilter(c,e,tp)
 	return c:IsSetCard(0x2b) and c:IsLevelBelow(4) 
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -46,11 +46,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
 	if tc then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
-		if tc:IsFacedown() then
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 and tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end
 	end

--- a/official/c65046521.lua
+++ b/official/c65046521.lua
@@ -30,7 +30,7 @@ end
 s.listed_series={0x0c0}
 function s.filter(c,e,tp)
 	return  c:IsRace(RACE_SPELLCASTER) and c:IsDefense(1500)
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -43,10 +43,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.filter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
 	if tc then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if Duel.SpecialSummon(tc,0,tp,tp,false,false,spos) then
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE) then
 			if tc:IsFacedown() then
 				Duel.ConfirmCards(1-tp,tc)
 			end

--- a/official/c68812773.lua
+++ b/official/c68812773.lua
@@ -1,4 +1,5 @@
 --オボミ
+--Lillybot
 local s,id=GetID()
 function s.initial_effect(c)
 	--summon,flip
@@ -29,7 +30,7 @@ s.listed_series={0x7b,0x55}
 s.listed_names={71071546}
 function s.filter(c,e,tp)
 	return c:IsCode(71071546)
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
@@ -42,11 +43,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
-		if tc:IsFacedown() then
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 and tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end
 	end

--- a/official/c74762582.lua
+++ b/official/c74762582.lua
@@ -63,7 +63,7 @@ function s.posfilter(c)
 	return c:IsFaceup() and c:IsCanTurnSet()
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(0xed) and (c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+	return c:IsSetCard(0xed) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and s.posfilter(chkc) end
@@ -83,11 +83,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,e,tp)
 		local tc=g:GetFirst()
 		if not tc then return end
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) then spos=spos+POS_FACEUP_DEFENSE end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 then
-			Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_DEFENSE)~=0 then
 			if tc:IsFacedown() then
 				Duel.ConfirmCards(1-tp,tc)
 			end

--- a/official/c76442347.lua
+++ b/official/c76442347.lua
@@ -1,4 +1,5 @@
 --子型ペンギン
+--Puny Penguin
 local s,id=GetID()
 function s.initial_effect(c)
 	--flip effect
@@ -29,8 +30,7 @@ function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.filter(c,e,tp)
 	return c:IsSetCard(0x5a) and c:GetCode()~=id
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
@@ -42,9 +42,6 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 then Duel.SpecialSummon(tc,0,tp,tp,false,false,spos) end
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 	end
 end

--- a/official/c93775296.lua
+++ b/official/c93775296.lua
@@ -1,4 +1,5 @@
 --リバース・リユース
+--Reverse Reuse
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -13,7 +14,7 @@ function s.initial_effect(c)
 end
 function s.filter(c,e,tp)
 	return c:IsType(TYPE_FLIP)
-		and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_DEFENSE)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
@@ -35,10 +36,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if #g>ft or (#g>1 and Duel.IsPlayerAffectedByEffect(tp,CARD_BLUEEYES_SPIRIT)) then return end
 	local tc=g:GetFirst()
 	for tc in aux.Next(g) do
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) then spos=spos+POS_FACEUP_DEFENSE end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		if spos~=0 then Duel.SpecialSummonStep(tc,0,tp,1-tp,false,false,spos) end
+		Duel.SpecialSummonStep(tc,0,tp,1-tp,false,false,POS_DEFENSE)
 	end
 	Duel.SpecialSummonComplete()
 end

--- a/official/c94365540.lua
+++ b/official/c94365540.lua
@@ -59,7 +59,7 @@ function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(0x10b) and (c:IsCanBeSpecialSummoned(e,0,tp,false,false) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+	return c:IsSetCard(0x10b) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
@@ -72,11 +72,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,e,tp)
 	local tc=g:GetFirst()
 	if tc then
-		local spos=0
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
-		if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)
-		if tc:IsFacedown() then
+		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK|POS_FACEDOWN_DEFENSE)~=0 and tc:IsFacedown() then
 			Duel.ConfirmCards(1-tp,tc)
 		end
 	end

--- a/pre-release/c101108021.lua
+++ b/pre-release/c101108021.lua
@@ -105,6 +105,6 @@ function s.dspop(e,tp,eg,ep,ev,re,r,rp)
 			e2:SetValue(RESET_TURN_SET)
 			sc:RegisterEffect(e2)
 		end
-		Duel.SpecialSummonComplete()
 	end
+	Duel.SpecialSummonComplete()
 end


### PR DESCRIPTION
Now those cards calls will use a single call to Duel.SpecialSummon[Step] and Card.IsCanBeSpecialSummoned passing all the possible summon positions at once. This change is possible thanks to the recent change to cards like Gozen Match that will now use EFFECT_FORCE_SPSUMMON_POSITION thus allowing proper restrictions on the summoning position, no longer requiring to check both for faceup and facedown separately.