### PR TITLE
Update to Auxiliary.PlayFieldSpell

### DIFF
--- a/utility.lua
+++ b/utility.lua
@@ -1575,13 +1575,13 @@ end
 function Auxiliary.HarmonizingMagFilter(c,e,f)
 	return f and not f(e,c)
 end
-function Auxiliary.PlayFieldSpell(c,e,tp,eg,ep,ev,re,r,rp,p)
-	if not p then p=tp end
+function Auxiliary.PlayFieldSpell(c,e,tp,eg,ep,ev,re,r,rp,target_p)
+	if not target_p then target_p=tp end
 	if c then
-		local fc=Duel.GetFieldCard(p,LOCATION_SZONE,5)
+		local fc=Duel.GetFieldCard(target_p,LOCATION_SZONE,5)
 		if Duel.IsDuelType(DUEL_1_FIELD) then
 			if fc then Duel.Destroy(fc,REASON_RULE) end
-			of=Duel.GetFieldCard(1-p,LOCATION_SZONE,5)
+			of=Duel.GetFieldCard(1-target_p,LOCATION_SZONE,5)
 			if of and Duel.Destroy(of,REASON_RULE)==0 then
 				Duel.SendtoGrave(c,REASON_RULE)
 				return false
@@ -1596,13 +1596,13 @@ function Auxiliary.PlayFieldSpell(c,e,tp,eg,ep,ev,re,r,rp,p)
 				Duel.BreakEffect()
 			end
 		end
-		Duel.MoveToField(c,tp,p,LOCATION_FZONE,POS_FACEUP,true)
+		Duel.MoveToField(c,tp,target_p,LOCATION_FZONE,POS_FACEUP,true)
 		local te=c:GetActivateEffect()
 		te:UseCountLimit(tp,1,true)
 		local tep=c:GetControler()
 		local cost=te:GetCost()
 		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end
-		Duel.RaiseEvent(c,4179255,te,0,tp,p,Duel.GetCurrentChain())
+		Duel.RaiseEvent(c,4179255,te,0,tp,target_p,Duel.GetCurrentChain())
 		return true
 	end
 	return false

--- a/utility.lua
+++ b/utility.lua
@@ -1575,12 +1575,13 @@ end
 function Auxiliary.HarmonizingMagFilter(c,e,f)
 	return f and not f(e,c)
 end
-function Auxiliary.PlayFieldSpell(c,e,tp,eg,ep,ev,re,r,rp)
+function Auxiliary.PlayFieldSpell(c,e,tp,eg,ep,ev,re,r,rp,p)
+	if not p then p=tp end
 	if c then
-		local fc=Duel.GetFieldCard(tp,LOCATION_SZONE,5)
+		local fc=Duel.GetFieldCard(p,LOCATION_SZONE,5)
 		if Duel.IsDuelType(DUEL_1_FIELD) then
 			if fc then Duel.Destroy(fc,REASON_RULE) end
-			of=Duel.GetFieldCard(1-tp,LOCATION_SZONE,5)
+			of=Duel.GetFieldCard(1-p,LOCATION_SZONE,5)
 			if of and Duel.Destroy(of,REASON_RULE)==0 then
 				Duel.SendtoGrave(c,REASON_RULE)
 				return false
@@ -1595,13 +1596,13 @@ function Auxiliary.PlayFieldSpell(c,e,tp,eg,ep,ev,re,r,rp)
 				Duel.BreakEffect()
 			end
 		end
-		Duel.MoveToField(c,tp,tp,LOCATION_FZONE,POS_FACEUP,true)
+		Duel.MoveToField(c,tp,p,LOCATION_FZONE,POS_FACEUP,true)
 		local te=c:GetActivateEffect()
 		te:UseCountLimit(tp,1,true)
 		local tep=c:GetControler()
 		local cost=te:GetCost()
 		if cost then cost(te,tep,eg,ep,ev,re,r,rp,1) end
-		Duel.RaiseEvent(c,4179255,te,0,tp,tp,Duel.GetCurrentChain())
+		Duel.RaiseEvent(c,4179255,te,0,tp,p,Duel.GetCurrentChain())
 		return true
 	end
 	return false


### PR DESCRIPTION
Added parameter "p" for target player (needed for the "Valiant" Field Spells)

<!--
Hello, thanks for submitting a pull request! Please provide enough information so we can review it.

If you are submitting an addition to the unofficial script project, the pull request title should be
of the form `Add "CARD NAME"`. Replace this comment with a Yugipedia link.

If you are submitting a bug fix, the pull request title should be of the form `Fix "CARD NAME"`.
In this case, replace this comment with a brief summary of your change. What did you fix?
--->

- [X] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

**New card checklist**

- [ ] I have submitted a corresponding database entry for [BabelCDB](https://github.com/ProjectIgnis/BabelCDB/blob/master/README.md) according to its guidelines. Link to the pull request: _fill in_
- [ ] This card is not marked with a reason to not be added in the unofficial card tracker in `#card-scripting-101`.
Supervising staff member(s): _fill in_
