### PR TITLE
Improve "There Can Be Only One" handling

### DIFF
--- a/official/c24207889.lua
+++ b/official/c24207889.lua
@@ -1,5 +1,6 @@
 --センサー万別
 --There Can Be Only One
+--Scripted by edo9300
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -10,11 +11,9 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 	--adjust
 	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
-	e2:SetCode(EVENT_ADJUST)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(id)
 	e2:SetRange(LOCATION_SZONE)
-	e2:SetOperation(s.adjustop)
 	c:RegisterEffect(e2)
 	--cannot summon,spsummon,flipsummon
 	local e4=Effect.CreateEffect(c)
@@ -32,44 +31,60 @@ function s.initial_effect(c)
 	local e6=e4:Clone()
 	e6:SetCode(EFFECT_CANNOT_FLIP_SUMMON)
 	c:RegisterEffect(e6)
+	aux.GlobalCheck(s,function()
+		s.lastFieldId={}
+		s.lastFieldId[0]=nil
+		s.lastFieldId[1]=nil
+		local ge=Effect.GlobalEffect()
+		ge:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+		ge:SetCode(EVENT_ADJUST)
+		ge:SetOperation(s.adjustop)
+		Duel.RegisterEffect(ge,0)
+	end)
 end
-s[0]={}
-s[1]={}
 function s.sumlimit(e,c,sump,sumtype,sumpos,targetp)
 	local tp=sump
 	if targetp then tp=targetp end
 	return Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsRace,c:GetRace()),tp,LOCATION_MZONE,0,1,c)
 end
 function s.fidfilter(c,fid)
-	return c:GetFieldID()~=fid
+	return c:GetFieldID()>fid
 end
+local faceupfil=aux.FilterFaceupFunction(Card.IsHasEffect,id)
 function s.adjustop(e,tp,eg,ep,ev,re,r,rp)
 	local phase=Duel.GetCurrentPhase()
 	if (phase==PHASE_DAMAGE and not Duel.IsDamageCalculated()) or phase==PHASE_DAMAGE_CAL then return end
+	if not Duel.IsExistingMatchingCard(faceupfil,0,LOCATION_SZONE,LOCATION_SZONE,1,nil) then
+		s.lastFieldId[0]=nil
+		s.lastFieldId[1]=nil
+		return
+	end
 	local sg=Group.CreateGroup()
 	for p=0,1 do
 		local g=Duel.GetMatchingGroup(Card.IsFaceup,p,LOCATION_MZONE,0,nil)
-		local race=1
-		while (RACE_ALL&race)~=0 do
-			local rg=g:Filter(Card.IsRace,nil,race)
-			local rc=#rg
-			if rc>1 then
-				local dg
-				if s[p][race] then
-					dg=rg:Filter(s.fidfilter,nil,s[p][race])
-				else
-					Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TOGRAVE)
-					dg=rg:Select(p,rc-1,rc-1,nil)
+		if #g==0 then
+			s.lastFieldId[p]=nil
+		else
+			local race=1
+			while (RACE_ALL&race)~=0 do
+				local rg=g:Filter(Card.IsRace,nil,race)
+				if s.lastFieldId[p] then
+					local forced
+					forced,rg=rg:Split(s.fidfilter,nil,s.lastFieldId[p])
+					sg:Merge(forced)
 				end
-				sg:Merge(dg)
+				local rc=#rg
+				if rc>1 then
+					Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TOGRAVE)
+					sg:Merge(rg:Select(p,rc-1,rc-1,nil))
+				end
+				race=race<<1
 			end
-			if rc==1 then
-				s[p][race]=rg:GetFirst():GetFieldID()
+			if not s.lastFieldId[p] then
+				local maxg,maxid=g:Sub(sg):GetMaxGroup(Card.GetFieldID)
+				s.lastFieldId[p]=maxid
 			end
-			if rc==0 then
-				s[p][race]=nil
-			end
-			race=race*2
 		end
 	end
 	if #sg>0 then

--- a/official/c24207889.lua
+++ b/official/c24207889.lua
@@ -67,12 +67,18 @@ function s.adjustop(e,tp,eg,ep,ev,re,r,rp)
 			s.lastFieldId[p]=nil
 		else
 			local race=1
+			local update_fid=false
 			while (RACE_ALL&race)~=0 do
 				local rg=g:Filter(Card.IsRace,nil,race)
 				if s.lastFieldId[p] then
 					local forced
 					forced,rg=rg:Split(s.fidfilter,nil,s.lastFieldId[p])
-					sg:Merge(forced)
+					if #rg==0 then
+						rg=forced
+						update_fid=true
+					else
+						sg:Merge(forced)
+					end
 				end
 				local rc=#rg
 				if rc>1 then
@@ -81,7 +87,7 @@ function s.adjustop(e,tp,eg,ep,ev,re,r,rp)
 				end
 				race=race<<1
 			end
-			if not s.lastFieldId[p] then
+			if update_fid or not s.lastFieldId[p] then
 				local maxg,maxid=g:Sub(sg):GetMaxGroup(Card.GetFieldID)
 				s.lastFieldId[p]=maxid
 			end


### PR DESCRIPTION
* Fixed an issue where the global state internal to the card would have been leaked when the card gets destroyed.
* Cleaned up the handling of the checking itself: now the card will keep track of the highest field id, and will automatically send to the GY cards with a greater id (in the case of returning to the field and changing controller, those are the only possible actions that would make a card touch the field).
* Handling of face-down monsters is "Undefined Behavior" as of now and needs to be properly investigated. At the moment if a monster is flipped by card effect it will be handled the same way as a monster that has just returned to the field or changed control.
