### PR TITLE
Fix Souleating Oviraptor (2nd effect) - Add Duel.GetMZoneCount check for the target

### DIFF
--- a/official/c44335251.lua
+++ b/official/c44335251.lua
@@ -41,25 +41,25 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_DECK,0,1,1,nil):GetFirst()
 	aux.ToHandOrElse(tc,tp)
 end
-function s.desfilter(c)
-	return c:IsFaceup() and c:IsLevelBelow(4) and c:IsRace(RACE_DINOSAUR)
+function s.desfilter(c,tp)
+	return c:IsFaceup() and c:IsLevelBelow(4) and c:IsRace(RACE_DINOSAUR) and Duel.GetMZoneCount(tp,c)>0
 end
 function s.spfilter(c,e,tp)
 	return c:IsRace(RACE_DINOSAUR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and s.desfilter(chkc) and chkc~=c end
-	if chk==0 then return Duel.IsExistingTarget(s.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,c)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and s.desfilter(chkc,tp) and chkc~=c end
+	if chk==0 then return Duel.IsExistingTarget(s.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,c,tp)
 		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,s.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,c)
+	local g=Duel.SelectTarget(tp,s.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,c,tp)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_GRAVE)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)>0 then
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
 		if #g>0 then

--- a/official/c44335251.lua
+++ b/official/c44335251.lua
@@ -49,7 +49,7 @@ function s.spfilter(c,e,tp)
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) and s.desfilter(chkc,tp) and chkc~=c end
+	if chkc then return chkc~=c and chkc:IsLocation(LOCATION_MZONE) and s.desfilter(chkc,tp) end
 	if chk==0 then return Duel.IsExistingTarget(s.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,c,tp)
 		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)


### PR DESCRIPTION
Currently, the second effect of Souleating Oviraptor does not check whether the designated target will leave a free Main Monster Zone after being destroyed. This can lead to incorrect behaviours, as showed in the replay inside the attached .zip: if all MMZs are occupied when said effect is activated, the player can potentially target a monster in the EMZ or that is controlled by the opponent; at resolution, the target is destroyed, but the player will not be able to Special Summon a monster from the GY. In this situation, the player should be forced to only target a monster on their MMZ, in order to free up space (as also confirmed in the ruling channel of the Discord server).

This fix aims to correct this issue by calling Duel.GetMZoneCount in the s.desfilter function.
[OviraptorBug.zip](https://github.com/ProjectIgnis/CardScripts/files/8791540/OviraptorBug.zip)
