### PR TITLE
Link Party Fix

### DIFF
--- a/official/c68957925.lua
+++ b/official/c68957925.lua
@@ -12,12 +12,31 @@ function s.initial_effect(c)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
+	if not AshBlossomTable then AshBlossomTable={} end
+	table.insert(AshBlossomTable,e1)
 end
 function s.filter(c)
 	return c:IsFaceup() and c:IsLinkMonster()
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil) end
+	local ct=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetClassCount(Card.GetOriginalAttribute)
+	if chk==0 then
+		return ct==3 or ct==4
+			or ct==1 and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil) 
+			or ct==2 and Duel.IsExistingMatchingCard(s.filter,tp,0,LOCATION_MZONE,1,nil)
+			or ct==5 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) 			
+			or ct==6 and Duel.IsExistingMatchingCard(s.desfilter,tp,0,LOCATION_MZONE,1,nil)
+	end
+	if ct==3 then
+		Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,1500)
+	elseif ct==4 then
+		Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,2000)
+	elseif ct==5 then
+		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+	elseif ct==6 then
+		local g=Duel.GetMatchingGroup(s.desfilter,tp,0,LOCATION_MZONE,nil)
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
+	end
 end
 function s.spfilter(c,e,tp)
 	return c:IsAttackAbove(2500) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
@@ -26,10 +45,10 @@ function s.desfilter(c)
 	return c:IsFaceup() and c:IsAttackBelow(3000)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local ct=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetClassCount(Card.GetAttribute)
-	local g1=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,0,nil)
-	if ct==1 and #g1>0 then
-		local tc1=g1:GetFirst()
+	local ct=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetClassCount(Card.GetOriginalAttribute)
+	if ct==1 then
+		local g1=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,0,nil)
+		if #g1==0 then return end
 		for tc1 in aux.Next(g1) do
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
@@ -38,11 +57,9 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 			e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 			tc1:RegisterEffect(e1)
 		end
-	end
-	local g2=Duel.GetMatchingGroup(s.filter,tp,0,LOCATION_MZONE,nil)
-	if ct==2 and #g2>0 then
-		Duel.BreakEffect()
-		local tc2=g2:GetFirst()
+	elseif ct==2 then
+		local g2=Duel.GetMatchingGroup(s.filter,tp,0,LOCATION_MZONE,nil)
+		if #g2==0 then return end
 		for tc2 in aux.Next(g2) do
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
@@ -51,25 +68,20 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 			e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 			tc2:RegisterEffect(e1)
 		end
-	end
-	if ct==3 then
-		Duel.BreakEffect()
+	elseif ct==3 then
 		Duel.Recover(tp,1500,REASON_EFFECT)
-	end
-	if ct==4 then
-		Duel.BreakEffect()
+	elseif ct==4 then
 		Duel.Damage(1-tp,2000,REASON_EFFECT)
-	end
-	local g3=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
-	if ct==5 and #g3>0 then
-		Duel.BreakEffect()
+	elseif ct==5 then
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
+		local g3=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_DECK,0,nil,e,tp)
+		if #g3==0 then return end
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local sg=g3:Select(tp,1,1,nil)
 		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
-	end
-	local g4=Duel.GetMatchingGroup(s.desfilter,tp,0,LOCATION_MZONE,nil)
-	if ct==6 and #g4>0 then
-		Duel.BreakEffect()
+	elseif ct==6 then
+		local g4=Duel.GetMatchingGroup(s.desfilter,tp,0,LOCATION_MZONE,nil)
+		if #g4==0 then return end
 		Duel.Destroy(g4,REASON_EFFECT)
 	end
 end

--- a/official/c68957925.lua
+++ b/official/c68957925.lua
@@ -1,6 +1,5 @@
 --リンク・パーティー
 --Link Party
---
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -12,20 +11,22 @@ function s.initial_effect(c)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
-	if not AshBlossomTable then AshBlossomTable={} end
-	table.insert(AshBlossomTable,e1)
 end
-function s.filter(c)
-	return c:IsFaceup() and c:IsLinkMonster()
+function s.spfilter(c,e,tp)
+	return c:IsAttackAbove(2500) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function s.desfilter(c)
+	return c:IsFaceup() and c:IsAttackBelow(3000)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ct=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetClassCount(Card.GetOriginalAttribute)
+	local lg=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsLinkMonster),tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local ct=lg:GetClassCount(Card.GetOriginalAttribute)
 	if chk==0 then
 		return ct==3 or ct==4
-			or ct==1 and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil) 
-			or ct==2 and Duel.IsExistingMatchingCard(s.filter,tp,0,LOCATION_MZONE,1,nil)
-			or ct==5 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) 			
-			or ct==6 and Duel.IsExistingMatchingCard(s.desfilter,tp,0,LOCATION_MZONE,1,nil)
+			or (ct==1 and lg:FilterCount(Card.IsControler,nil,tp)>0)
+			or (ct==2 and lg:FilterCount(Card.IsControler,nil,1-tp)>0)
+			or (ct==5 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp))
+			or (ct==6 and Duel.IsExistingMatchingCard(s.desfilter,tp,0,LOCATION_MZONE,1,nil))
 	end
 	if ct==3 then
 		Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,1500)
@@ -37,19 +38,15 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		local g=Duel.GetMatchingGroup(s.desfilter,tp,0,LOCATION_MZONE,nil)
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
 	end
-end
-function s.spfilter(c,e,tp)
-	return c:IsAttackAbove(2500) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-end
-function s.desfilter(c)
-	return c:IsFaceup() and c:IsAttackBelow(3000)
+	Duel.SetPossibleOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local ct=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetClassCount(Card.GetOriginalAttribute)
+	local lg=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsLinkMonster),tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local ct=lg:GetClassCount(Card.GetOriginalAttribute)
 	if ct==1 then
-		local g1=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,0,nil)
+		local g1=lg:Filter(Card.IsControler,nil,tp)>0
 		if #g1==0 then return end
-		for tc1 in aux.Next(g1) do
+		for tc1 in g1:Iter() do
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_UPDATE_ATTACK)
@@ -58,9 +55,9 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 			tc1:RegisterEffect(e1)
 		end
 	elseif ct==2 then
-		local g2=Duel.GetMatchingGroup(s.filter,tp,0,LOCATION_MZONE,nil)
+		local g2=lg:Filter(Card.IsControler,nil,1-tp)
 		if #g2==0 then return end
-		for tc2 in aux.Next(g2) do
+		for tc2 in g2:Iter() do
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
 			e1:SetCode(EFFECT_UPDATE_ATTACK)


### PR DESCRIPTION
Link Party's script has a series of issues that this pull request aims to fix:
- The script needs to count the **original Attributes** instead of the current Attributes of Links on the field.
- The target function needs to check whether you can activate Link Party depending on the number of different original Attributes (related ruling: https://db.ygorganization.com/qa#21928)
- Ash Blossom can always respond to Link Party (even when there are not exactly 5 different original Attributes among Links), thus the effect needs to be inserted into the Ash Blossom Table.
- If Link Party is activated while there are 6 different Attributes among Links on the field, then Stardust Dragon can respond to it (according to https://db.ygorganization.com/qa#10790): the script needs to call Duel.SetOperationInfo in order to allow this.
- At resolution, only 1 effect is applied in any case; the operation function does not need to check every "if" line.