### PR TITLE
Update for cards that check for Main Monster Zones that Link Monsters/Cards point to

### DIFF
--- a/official/c27918365.lua
+++ b/official/c27918365.lua
@@ -1,7 +1,6 @@
 --星遺物－『星冠』
 --World Legacy - "World Crown"
 --Scripted by ahtelel
-
 local s,id=GetID()
 function s.initial_effect(c)
 	--Special Summon itself from hand
@@ -42,9 +41,8 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 s.listed_series={0xfe}
-
 function s.spval(e,c)
-	return 0,Duel.GetLinkedZone(c:GetControler())&0x1f
+	return 0,aux.GetMMZonesPointedTo(c:GetControler())
 end
 function s.negcon(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()

--- a/official/c28031913.lua
+++ b/official/c28031913.lua
@@ -1,7 +1,6 @@
 --百獣のパラディオン
 --Crusadia Leonis
 --Scripted by ahtelel
-
 local s,id=GetID()
 function s.initial_effect(c)
 	--Special Summon itself from hand
@@ -19,8 +18,8 @@ function s.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,1))
 	e2:SetType(EFFECT_TYPE_IGNITION)
-	e2:SetRange(LOCATION_MZONE)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_MZONE)
 	e2:SetCountLimit(1,{id,1})
 	e2:SetCondition(s.condition)
 	e2:SetTarget(s.target)
@@ -28,9 +27,8 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 s.listed_series={0x116}
-
 function s.spval(e,c)
-	return 0,Duel.GetLinkedZone(c:GetControler())&0x1f
+	return 0,aux.GetMMZonesPointedTo(c:GetControler())
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()
@@ -46,7 +44,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) then
 		--Inflict piercing damage
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetDescription(3208)

--- a/official/c36492575.lua
+++ b/official/c36492575.lua
@@ -1,7 +1,6 @@
 --海晶乙女 シーホース
 --Marincess Sea Horse
 --Scripted by Larry126
-
 local s,id=GetID()
 function s.initial_effect(c)
 	--Special Summon itself from hand
@@ -28,24 +27,20 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 s.listed_series={0x12b}
-
-function s.filter(c)
-	return c:IsFaceup() and c:IsSetCard(0x12b) and c:IsLinkMonster()
-end
 function s.spval(e,c)
-	return 0,Duel.GetMatchingGroup(s.filter,0,LOCATION_MZONE,LOCATION_MZONE,nil):GetLinkedZone(c:GetControler())&0x1f
+	return 0,aux.GetMMZonesPointedTo(c:GetControler(),Card.IsSetCard,nil,nil,nil,0x12b)
 end
 function s.spfilter(c,e,tp,zone)
 	return c:IsAttribute(ATTRIBUTE_WATER) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local zone=Duel.GetMatchingGroup(s.filter,0,LOCATION_MZONE,LOCATION_MZONE,nil):GetLinkedZone(tp)&0x1f
+	local zone=aux.GetMMZonesPointedTo(tp,Card.IsSetCard,nil,nil,nil,0x12b)
 	if chk==0 then return zone~=0 and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp,zone) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
-	local zone=Duel.GetMatchingGroup(s.filter,0,LOCATION_MZONE,LOCATION_MZONE,nil):GetLinkedZone(tp)&0x1f
+	local zone=aux.GetMMZonesPointedTo(tp,Card.IsSetCard,nil,nil,nil,0x12b)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp,zone)
 	if #g>0 then

--- a/official/c54525057.lua
+++ b/official/c54525057.lua
@@ -1,25 +1,24 @@
 --星辰のパラディオン
 --Crusadia Draco
 --Scripted by ahtelel
-
 local s,id=GetID()
 function s.initial_effect(c)
 	--Special Summon itself from hand
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SPSUM_PARAM)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetTargetRange(POS_FACEUP_DEFENSE,0)
 	e1:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)
 	e1:SetValue(s.spval)
 	c:RegisterEffect(e1)
-	--If Normal or Special Summoned, add 1 "Crusadia" card from GY to hand
+	--Add 1 "Crusadia" card from GY to hand
 	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_TOHAND)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetCountLimit(1,{id,1})
 	e2:SetCondition(s.thcon)
@@ -32,30 +31,26 @@ function s.initial_effect(c)
 end
 s.listed_series={0x116}
 s.listed_names={id}
-
 function s.spval(e,c)
-	return 0,Duel.GetLinkedZone(c:GetControler())&0x1f
-end
-function s.filter1(c)
-	return c:IsSetCard(0x116) and not c:IsCode(id) and c:IsAbleToHand()
-end
-function s.filter2(c,ec)
-	return c:IsFaceup() and c:IsLinkMonster() and c:GetLinkedGroup():IsContains(ec)
+	return 0,aux.GetMMZonesPointedTo(c:GetControler())
 end
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetLinkedGroup(tp,LOCATION_MZONE,0):IsContains(e:GetHandler())
+	local zone=aux.GetMMZonesPointedTo(tp)
+	return aux.IsZone(e:GetHandler(),zone,tp)
+end
+function s.thfilter(c)
+	return c:IsSetCard(0x116) and not c:IsCode(id) and c:IsAbleToHand()
 end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter1(chkc) and s.filter2(chkc,e:GetHandler()) end
-	if chk==0 then return Duel.IsExistingTarget(s.filter1,tp,LOCATION_GRAVE,0,1,nil) end
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.thfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(s.thfilter,tp,LOCATION_GRAVE,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-	local g=Duel.SelectTarget(tp,s.filter1,tp,LOCATION_GRAVE,0,1,1,nil)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+	local g=Duel.SelectTarget(tp,s.thfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,tp,0)
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)
 	end
 end
-

--- a/official/c54658815.lua
+++ b/official/c54658815.lua
@@ -15,26 +15,19 @@ end
 function s.filter(c,e,tp,zone)
 	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,1-tp,zone)
 end
-function s.zonefilter(tp)
-	local lg=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsLinkMonster),tp,LOCATION_MZONE,0,nil)
-	local zone=0
-	for tc in aux.Next(lg) do
-		zone=zone|tc:GetLinkedZone()>>16
-	end
-	return zone
-end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local zone=s.zonefilter(tp)
+	local zone=aux.GetMMZonesPointedTo(tp,nil,LOCATION_MZONE,0,1-tp)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and s.filter(chkc,e,tp,zone) end
-	if chk==0 then return zone~=0 and Duel.IsExistingTarget(s.filter,tp,0,LOCATION_GRAVE,1,nil,e,tp,zone) end
+	if chk==0 then return zone>0 and Duel.IsExistingTarget(s.filter,tp,0,LOCATION_GRAVE,1,nil,e,tp,zone) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectTarget(tp,s.filter,tp,0,LOCATION_GRAVE,1,1,nil,e,tp,zone)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
-		local zone=s.zonefilter(tp)
+	if not tc:IsRelateToEffect(e) then return end
+	local zone=aux.GetMMZonesPointedTo(tp,nil,LOCATION_MZONE,0,1-tp)
+	if zone>0 then
 		Duel.SpecialSummon(tc,0,tp,1-tp,false,false,POS_FACEUP,zone)
 	end
 end

--- a/official/c55241609.lua
+++ b/official/c55241609.lua
@@ -1,24 +1,23 @@
 --魔境のパラディオン
 --Crusadia Reclusia
 --Scripted by ahtelel
-
 local s,id=GetID()
 function s.initial_effect(c)
 	--Special Summon itself from hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SPSUM_PARAM)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetTargetRange(POS_FACEUP_DEFENSE,0)
 	e1:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)
 	e1:SetValue(s.spval)
 	c:RegisterEffect(e1)
-	--If Normal or Special Summoned, destroy 1 of your "Crusadia" cards and 1 of opponent's cards
+	--Destroy 1 of your "Crusadia" cards and 1 opponent's card
 	local e2=Effect.CreateEffect(c)
 	e2:SetCategory(CATEGORY_DESTROY)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
 	e2:SetCode(EVENT_SUMMON_SUCCESS)
 	e2:SetCountLimit(1,{id,1})
 	e2:SetCondition(s.descon)
@@ -30,15 +29,15 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 s.listed_series={0x116}
-
 function s.spval(e,c)
-	return 0,Duel.GetLinkedZone(c:GetControler())&0x1f
+	return 0,aux.GetMMZonesPointedTo(c:GetControler())
+end
+function s.descon(e,tp,eg,ep,ev,re,r,rp)
+	local zone=aux.GetMMZonesPointedTo(tp)
+	return aux.IsZone(e:GetHandler(),zone,tp)
 end
 function s.filter(c)
 	return c:IsFaceup() and c:IsSetCard(0x116)
-end
-function s.descon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetLinkedGroup(tp,LOCATION_MZONE,0):IsContains(e:GetHandler())
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end

--- a/official/c65100616.lua
+++ b/official/c65100616.lua
@@ -1,20 +1,18 @@
 --リンク・インフライヤー
 --Link Infra-Flier
 --Scripted by Eerie Code
-
 local s,id=GetID()
 function s.initial_effect(c)
 	--Special Summon itself from hand
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)
 	e1:SetValue(s.spval)
 	c:RegisterEffect(e1)
 end
 function s.spval(e,c)
-	return 0,Duel.GetLinkedZone(c:GetControler())&0x1f
+	return 0,aux.GetMMZonesPointedTo(c:GetControler())
 end

--- a/official/c67127799.lua
+++ b/official/c67127799.lua
@@ -3,17 +3,18 @@
 --Scripted by edo9300
 local s,id=GetID()
 function s.initial_effect(c)
-	--special summon self
+	--Special Summon this card
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)
 	e1:SetValue(s.spval)
 	c:RegisterEffect(e1)
-	--special summon a dark dragon-machine
+	--Special Summon 1 DARK Dragon or Machine from your hand
 	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_MZONE)
@@ -24,24 +25,21 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 s.listed_names={id}
-function s.filter(c)
-	return c:IsType(TYPE_LINK) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsFaceup()
-end
 function s.spval(e,c)
-	return 0,Duel.GetMatchingGroup(s.filter,0,LOCATION_MZONE,LOCATION_MZONE,nil):GetLinkedZone(c:GetControler())&0x1f
+	return 0,aux.GetMMZonesPointedTo(c:GetControler(),Card.IsAttribute,nil,nil,nil,ATTRIBUTE_DARK)
 end
 function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsReleasable() end
-	Duel.Release(e:GetHandler(),REASON_COST)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsReleasable() end
+	Duel.Release(c,REASON_COST)
 end
 function s.spfilter(c,e,tp)
 	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsRace(RACE_MACHINE|RACE_DRAGON) and not c:IsCode(id)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if e:GetHandler():IsInMainMZone() then ft=ft+1 end
-	if chk==0 then return ft>0 and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return Duel.GetMZoneCount(tp,e:GetHandler())>0
+		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)

--- a/official/c67218327.lua
+++ b/official/c67218327.lua
@@ -1,60 +1,47 @@
---SIMM Dublas
+--ＳＩＭＭタブラス
+--SIMM Tablir
 --scripted by Naim
 local s,id=GetID()
 function s.initial_effect(c)
-	--return
+	--Special Summon this card
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
-	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOHAND)
 	e1:SetType(EFFECT_TYPE_IGNITION)
-	e1:SetRange(LOCATION_HAND)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_HAND)
 	e1:SetCountLimit(1,id)
-	e1:SetCost(s.cost)
-	e1:SetTarget(s.target)
-	e1:SetOperation(s.operation)
+	e1:SetCost(s.spcost)
+	e1:SetTarget(s.sptg)
+	e1:SetOperation(s.spop)
 	c:RegisterEffect(e1)
 end
-function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not e:GetHandler():IsPublic() end
+end
+function s.thfilter(c)
+	return c:IsRace(RACE_CYBERSE) and c:IsLevel(4) and c:IsAbleToHand()
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and s.thfilter(chkc) end
 	local c=e:GetHandler()
-	if chk==0 then return not c:IsPublic() end
-end
-function s.filter(c)
-	return c:IsRace(RACE_CYBERSE) and c:GetLevel()==4
-end
-function s.filter2(c)
-	return c:IsLinkMonster() and c:IsLinked() and c:IsFaceup()
-end
-function s.getzone(tp)
-	local zone = 0
-	local g = Duel.GetMatchingGroup(s.filter2,tp,LOCATION_MZONE,0,nil)
-	for tc in aux.Next(g) do
-		zone = zone | tc:GetLinkedZone()
-	end
-	return zone&0x1f
-end
-function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local zone=s.getzone(tp)
-	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and s.filter(chkc) end
-	local c=e:GetHandler()
-	if chk==0 then return zone~=0 and
-		c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
+	local zone=aux.GetMMZonesPointedTo(tp,Card.IsLinked,LOCATION_MZONE,0)
+	if chk==0 then return zone>0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingTarget(s.filter,tp,LOCATION_GRAVE,0,1,e:GetHandler(),e,tp,zone) end
+		and Duel.IsExistingTarget(s.thfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,zone) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
-	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_GRAVE,0,1,1,e:GetHandler(),e,tp,zone)
-	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+	local g=Duel.SelectTarget(tp,s.thfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,zone)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,tp,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,tp,0)
 end
-function s.operation(e,tp,eg,ep,ev,re,r,rp)
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local zone=s.getzone(tp)
 	if not c:IsRelateToEffect(e) then return end
-	if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)~=0 then
+	local zone=aux.GetMMZonesPointedTo(tp,Card.IsLinked,LOCATION_MZONE,0)
+	if zone>0 and Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)>0 then
 		local tc=Duel.GetFirstTarget()
-		if tc:IsRelateToEffect(e) then
+		if tc:IsRelateToEffect(e) and s.thfilter(tc) then
 			Duel.SendtoHand(tc,nil,REASON_EFFECT)
 		end
 	end
 end
-

--- a/official/c81524756.lua
+++ b/official/c81524756.lua
@@ -1,15 +1,13 @@
 --天穹のパラディオン
 --Crusadia Maximus
 --Scripted by ahtelel
-
 local s,id=GetID()
 function s.initial_effect(c)
 	--Special Summon itself from hand
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SPSUM_PARAM)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
 	e1:SetRange(LOCATION_HAND)
 	e1:SetTargetRange(POS_FACEUP_DEFENSE,0)
 	e1:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)
@@ -17,7 +15,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 	--Make 1 "Crusadia" link monster deal double battle damage
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetCountLimit(1,{id,1})
@@ -28,15 +26,14 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 s.listed_series={0x116}
-
 function s.spval(e,c)
-	return 0,Duel.GetLinkedZone(c:GetControler())&0x1f
+	return 0,aux.GetMMZonesPointedTo(c:GetControler())
 end
 function s.dbcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsAbleToEnterBP()
 end
 function s.dbfilter(c)
-	return c:IsFaceup() and c:IsLinkMonster() and c:IsSetCard(0x116) and c:GetFlagEffect(id)==0
+	return c:IsFaceup() and c:IsLinkMonster() and c:IsSetCard(0x116)
 end
 function s.dbtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and s.dbfilter(chkc) end
@@ -45,10 +42,9 @@ function s.dbtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SelectTarget(tp,s.dbfilter,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function s.dbop(e,tp,eg,ep,ev,re,r,rp)
-	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
-		tc:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,0)
+	if tc:IsRelateToEffect(e) then
+		local c=e:GetHandler()
 		--Deal double battle damage
 		local e1=Effect.CreateEffect(c)
 		e1:SetDescription(3209)

--- a/official/c84121193.lua
+++ b/official/c84121193.lua
@@ -49,14 +49,16 @@ function s.spfilter(c,e,tp,p,zones)
 	return c:IsCode(8662794) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,p,zones)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,nil,e,tp,tp,Duel.GetLinkedZone(tp)&0x1f)
-		or Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,nil,e,tp,1-tp,Duel.GetLinkedZone(1-tp)&0x1f) end
+	local zones_tp=aux.GetMMZonesPointedTo(tp)
+	local zones_opp=aux.GetMMZonesPointedTo(1-tp)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,nil,e,tp,tp,zones_tp)
+		or Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,nil,e,tp,1-tp,zones_opp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local zones={}
-	zones[tp]=Duel.GetLinkedZone(tp)&0x1f
-	zones[1-tp]=Duel.GetLinkedZone(1-tp)&0x1f
+	zones[tp]=aux.GetMMZonesPointedTo(tp)
+	zones[1-tp]=aux.GetMMZonesPointedTo(1-tp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tc=(Duel.GetMatchingGroup(aux.NecroValleyFilter(s.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,nil,e,tp,tp,zones[tp])+Duel.GetMatchingGroup(aux.NecroValleyFilter(s.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,nil,e,tp,1-tp,zones[1-tp])):Select(tp,1,1,nil):GetFirst()
 	if tc then

--- a/official/c84899094.lua
+++ b/official/c84899094.lua
@@ -2,25 +2,25 @@
 --World Chalice Guardragon
 local s,id=GetID()
 function s.initial_effect(c)
-	--negate
+	--Negate the activation of an effect that targets your linked monster
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
 	e1:SetCode(EVENT_CHAINING)
 	e1:SetRange(LOCATION_HAND+LOCATION_MZONE)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
-	e1:SetCondition(s.condition)
-	e1:SetCost(s.cost)
-	e1:SetTarget(s.target)
-	e1:SetOperation(s.operation)
+	e1:SetCondition(s.negcon)
+	e1:SetCost(s.negcost)
+	e1:SetTarget(s.negtg)
+	e1:SetOperation(s.negop)
 	c:RegisterEffect(e1)
-	--spsummon
+	--Special Summon 1 Normal Monster from your GY
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,1))
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetRange(LOCATION_GRAVE)
 	e2:SetCountLimit(1,id)
 	e2:SetCost(aux.bfgcost)
@@ -28,27 +28,28 @@ function s.initial_effect(c)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
 end
-function s.filter(c,tp)
+function s.cfilter(c,tp)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsLinked()
 end
-function s.condition(e,tp,eg,ep,ev,re,r,rp)
+function s.negcon(e,tp,eg,ep,ev,re,r,rp)
 	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
 	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
-	return g and g:IsExists(s.filter,1,nil,tp)
-		and Duel.IsChainNegatable(ev)
+	return g:IsExists(s.cfilter,1,nil,tp) and Duel.IsChainNegatable(ev)
 end
-function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
-	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+function s.negcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToGraveAsCost() end
+	Duel.SendtoGrave(c,REASON_COST)
 end
-function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
-	if re:GetHandler():IsRelateToEffect(re) and re:GetHandler():IsDestructable() then
+	local rc=re:GetHandler()
+	if rc:IsRelateToEffect(re) and rc:IsDestructable() then
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
 	end
 end
-function s.operation(e,tp,eg,ep,ev,re,r,rp)
+function s.negop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
 		Duel.Destroy(eg,REASON_EFFECT)
 	end
@@ -57,18 +58,17 @@ function s.spfilter(c,e,tp,zone)
 	return c:IsType(TYPE_NORMAL) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE,tp,zone)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local zone=Duel.GetLinkedZone(tp)&0x1f
+	local zone=aux.GetMMZonesPointedTo(tp)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and s.spfilter(chkc,e,tp,zone) end
-	if chk==0 then return zone~=0
-		and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_GRAVE,0,1,e:GetHandler(),e,tp,zone) end
+	if chk==0 then return zone>0 and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_GRAVE,0,1,e:GetHandler(),e,tp,zone) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local tg=Duel.SelectTarget(tp,s.spfilter,tp,LOCATION_GRAVE,0,1,1,e:GetHandler(),e,tp,zone)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tg,1,0,0)
+	local tg=Duel.SelectTarget(tp,s.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,zone)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tg,1,tp,0)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
-	local zone=Duel.GetLinkedZone(tp)&0x1f
+	local zone=aux.GetMMZonesPointedTo(tp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) and zone~=0 then
+	if tc:IsRelateToEffect(e) and zone>0 then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE,zone)
 	end
 end

--- a/official/c89484053.lua
+++ b/official/c89484053.lua
@@ -3,7 +3,7 @@
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
-	--spsummon
+	--Special Summon this card from the hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -14,15 +14,16 @@ function s.initial_effect(c)
 	e1:SetTarget(s.sptg)
 	e1:SetOperation(s.spop)
 	c:RegisterEffect(e1)
-	--shuffle and draw
+	--Shuffle 5 "Salamangreat" cards from your GY to the Deck and draw 2 cards
 	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
 	e2:SetCategory(CATEGORY_TODECK+CATEGORY_DRAW)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetRange(LOCATION_GRAVE)
 	e2:SetCountLimit(1,{id,1})
+	e2:SetCondition(function(_,tp) return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0 end)
 	e2:SetCost(aux.bfgcost)
-	e2:SetCondition(s.drcon)
 	e2:SetTarget(s.drtg)
 	e2:SetOperation(s.drop)
 	c:RegisterEffect(e2)
@@ -37,42 +38,35 @@ function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	local zone=Duel.GetLinkedZone(tp)&0x1f
-	if chk==0 then return zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+	local zone=aux.GetMMZonesPointedTo(tp)
+	if chk==0 then return zone>0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,tp,0)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local zone=Duel.GetLinkedZone(tp)&0x1f
-	if zone~=0 and c:IsRelateToEffect(e) then
+	local zone=aux.GetMMZonesPointedTo(tp)
+	if zone>0 and c:IsRelateToEffect(e) then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)
 	end
 end
-function s.drcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==0
-end
-function s.filter(c)
+function s.tdfilter(c)
 	return c:IsSetCard(0x119) and c:IsAbleToDeck()
 end
 function s.drtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc) end
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.tdfilter(chkc) end
 	if chk==0 then return Duel.IsPlayerCanDraw(tp,2)
-		and Duel.IsExistingTarget(s.filter,tp,LOCATION_GRAVE,0,5,e:GetHandler()) end
+		and Duel.IsExistingTarget(s.tdfilter,tp,LOCATION_GRAVE,0,5,e:GetHandler()) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_GRAVE,0,5,5,nil)
-	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,#g,0,0)
+	local g=Duel.SelectTarget(tp,s.tdfilter,tp,LOCATION_GRAVE,0,5,5,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,#g,tp,0)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)
 end
 function s.drop(e,tp,eg,ep,ev,re,r,rp)
-	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
-	if not tg or tg:FilterCount(Card.IsRelateToEffect,nil,e)~=5 then return end
-	Duel.SendtoDeck(tg,nil,0,REASON_EFFECT)
-	local g=Duel.GetOperatedGroup()
-	if g:IsExists(Card.IsLocation,1,nil,LOCATION_DECK) then Duel.ShuffleDeck(tp) end
-	local ct=g:FilterCount(Card.IsLocation,nil,LOCATION_DECK+LOCATION_EXTRA)
-	if ct==5 then
-		Duel.BreakEffect()
-		Duel.Draw(tp,2,REASON_EFFECT)
-	end
+	local tg=Duel.GetTargetCards(e)
+	if #tg==0 or Duel.SendtoDeck(tg,nil,SEQ_DECKSHUFFLE,REASON_EFFECT)==0 then return end
+	local og=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_DECK+LOCATION_EXTRA)
+	if #og==0 then return end
+	if og:IsExists(Card.IsLocation,1,nil,LOCATION_DECK) then Duel.ShuffleDeck(tp) end
+	Duel.BreakEffect()
+	Duel.Draw(tp,2,REASON_EFFECT)
 end
-

--- a/official/c91557476.lua
+++ b/official/c91557476.lua
@@ -85,7 +85,7 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local bc=e:GetHandler():GetBattleTarget()
-	local zone=Duel.GetLinkedZone(tp)&0x1f
+	local zone=aux.GetMMZonesPointedTo(tp)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and bc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone) end
 	Duel.SetTargetCard(bc)
@@ -94,7 +94,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	local zone=Duel.GetLinkedZone(tp)&0x1f
+	local zone=aux.GetMMZonesPointedTo(tp)
 	if zone~=0 and tc and tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP,zone)~=0 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)

--- a/official/c91646304.lua
+++ b/official/c91646304.lua
@@ -1,7 +1,6 @@
 --神樹のパラディオン
 --Crusadia Arboria
 --Scripted by ahtelel
-
 local s,id=GetID()
 function s.initial_effect(c)
 	--Special Summon itself from hand
@@ -26,9 +25,8 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 s.listed_series={0x116}
-
 function s.spval(e,c)
-	return 0,Duel.GetLinkedZone(c:GetControler())&0x1f
+	return 0,aux.GetMMZonesPointedTo(c:GetControler())
 end
 function s.repfilter(c,tp)
 	return c:IsFaceup() and c:IsSetCard(0x116) and c:IsLocation(LOCATION_MZONE)

--- a/official/c99674361.lua
+++ b/official/c99674361.lua
@@ -1,35 +1,35 @@
 --星遺物を継ぐもの
---World Legacy Successor
+--World Legacy Succession
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 end
-function s.filter(c,e,tp,zone)
+function s.spfilter(c,e,tp,zone)
 	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local zone=Duel.GetLinkedZone(tp)&0x1f
-	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp,zone) end
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingTarget(s.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp,zone) end
+	local zone=aux.GetMMZonesPointedTo(tp)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.spfilter(chkc,e,tp,zone) end
+	if chk==0 then return zone>0 and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,zone) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,zone)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+	local g=Duel.SelectTarget(tp,s.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,zone)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,tp,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	local zone=Duel.GetLinkedZone(tp)&0x1f
-	if tc and tc:IsRelateToEffect(e) and zone~=0 then
+	local zone=aux.GetMMZonesPointedTo(tp)
+	if tc:IsRelateToEffect(e) and zone>0 then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP,zone)
 	end
 end

--- a/pre-release/c101110074.lua
+++ b/pre-release/c101110074.lua
@@ -14,13 +14,6 @@ function s.initial_effect(c)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 end
-function s.lnkfilter(c)
-	return c:IsLinkMonster() and c:IsLink(2)
-end
-function s.getzones(tp)
-	local lg=Duel.GetMatchingGroup(s.lnkfilter,tp,LOCATION_MZONE,0,nil)
-	return lg:GetLinkedZone(tp)
-end
 function s.atchfilter(c,tp)
 	return (c:IsControler(tp) or c:IsLocation(LOCATION_GRAVE) or c:IsAbleToChangeControler()) and c:IsMonster()
 		and Duel.IsExistingMatchingCard(s.xyzfilter,tp,LOCATION_MZONE,0,1,c)
@@ -35,7 +28,7 @@ function s.spfilter(c,e,tp,zone)
 	return c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local zone=s.getzones(tp)
+	local zone=aux.GetMMZonesPointedTo(tp,Card.IsLink,LOCATION_MZONE,0,nil,2)
 	local b1=Duel.IsExistingTarget(s.atchfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,nil,tp)
 	local b2=Duel.IsExistingTarget(s.ctrlfilter,tp,0,LOCATION_MZONE,1,nil,zone)
 	local b3=Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,nil,e,tp,zone)
@@ -77,7 +70,7 @@ end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not tc:IsRelateToEffect(e) then return end
-	local zone=s.getzones(tp)
+	local zone=aux.GetMMZonesPointedTo(tp,Card.IsLink,LOCATION_MZONE,0,nil,2)
 	local op=e:GetLabel()
 	if op==1 then --Attach it to a Rank 2
 		if not tc:IsImmuneToEffect(e) and Duel.IsExistingMatchingCard(s.xyzfilter,tp,LOCATION_MZONE,0,1,tc) then

--- a/unofficial/c511009503.lua
+++ b/unofficial/c511009503.lua
@@ -38,7 +38,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e4)
 end
 function s.zones(e,tp,eg,ep,ev,re,r,rp)
-	return (Duel.GetLinkedZone(tp)>>8) & 0xff
+	return (Duel.GetMatchingGroup(aux.AND(Card.IsFaceup,Card.IsLinkMonster),tp,LOCATION_MZONE,LOCATION_MZONE,nil):GetLinkedZone(tp)>>8) & 0xff
 end
 function s.atkcon(e)
 	if Duel.GetCurrentPhase()~=PHASE_DAMAGE_CAL then return false end

--- a/unofficial/c511009617.lua
+++ b/unofficial/c511009617.lua
@@ -40,7 +40,7 @@ function s.atcon(e)
 	return e:GetHandler():GetMutualLinkedGroupCount()>0
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local zone=Duel.GetLinkedZone(tp)&0x1f
+	local zone=aux.GetMMZonesPointedTo(tp)
 	local c=e:GetHandler()
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK,tp,zone) end
@@ -48,7 +48,7 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	local zone=Duel.GetLinkedZone(tp)&0x1f
+	local zone=aux.GetMMZonesPointedTo(tp)
 	if c:IsRelateToEffect(e) and zone~=0 then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)
 	end

--- a/unofficial/c511018036.lua
+++ b/unofficial/c511018036.lua
@@ -1,38 +1,33 @@
+--零重力
 --Love Gravity
-local cid, id = GetID()
-function cid.initial_effect(c)
-	--special summon
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetTarget(cid.target)
-	e1:SetOperation(cid.operation)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
 end
-function cid.spfilter(c,e,tp,zone)
+function s.spfilter(c,e,tp,zone)
 	return c:IsLinkMonster() and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 end
-function cid.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	local zone = 0
-	local g = Duel.GetMatchingGroup(Card.IsType,0,LOCATION_MZONE,LOCATION_MZONE,nil,TYPE_LINK)
-	for tc in aux.Next(g) do
-		zone = zone | (tc:GetLinkedZone(tp) & 0x1f)
-	end
-	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and cid.spfilter(chkc,e,tp,zone) end
-	if chk==0 then return Duel.IsExistingTarget(cid.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,zone) end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local zone=aux.GetMMZonesPointedTo(tp)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and s.spfilter(chkc,e,tp,zone) end
+	if chk==0 then return zone>0 and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,zone) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectTarget(tp,cid.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,zone)
+	local g=Duel.SelectTarget(tp,s.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp,zone)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
-function cid.operation(e,tp,eg,ep,ev,re,r,rp)
-	local zone = 0
-	local g = Duel.GetMatchingGroup(Card.IsType,0,LOCATION_MZONE,LOCATION_MZONE,nil,TYPE_LINK)
-	for tc in aux.Next(g) do
-		zone = zone | (tc:GetLinkedZone(tp) & 0x1f)
-	end
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	local zone=aux.GetMMZonesPointedTo(tp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) and zone ~= 0 then
+	if tc:IsRelateToEffect(e) and zone>0 then
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP,zone)
 	end
 end

--- a/unofficial/c511030051.lua
+++ b/unofficial/c511030051.lua
@@ -3,7 +3,7 @@
 --scripted by pyrQ
 local s,id=GetID()
 function s.initial_effect(c)
-	--special summon
+	--Special Summon this card from your hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -16,28 +16,24 @@ function s.initial_effect(c)
 end
 s.listed_series={0x57b}
 function s.cfilter(c)
-	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x57b) and c:IsAbleToGraveAsCost()
+	return c:IsMonster() and c:IsSetCard(0x57b) and c:IsAbleToGraveAsCost()
 end
 function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not e:GetHandler():IsPublic() and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_HAND,0,1,e:GetHandler()) end
-	Duel.DiscardHand(tp,s.cfilter,1,1,REASON_COST,e:GetHandler())
-end
-function s.zonefilter(tp)
-	local lg=Duel.GetMatchingGroup(Card.IsType,tp,LOCATION_MZONE,0,nil,TYPE_LINK)
-	local zone=0
-	for tc in aux.Next(lg) do
-		zone=zone|tc:GetLinkedZone()
-	end 
-	return zone
+	local c=e:GetHandler()
+	if chk==0 then return not c:IsPublic() and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_HAND,0,1,c) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_HAND,0,1,1,c)
+	Duel.SendtoGrave(g,REASON_EFFECT)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local zones=s.zonefilter(tp)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zones) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,LOCATION_HAND)
+	local c=e:GetHandler()
+	local zones=aux.GetMMZonesPointedTo(tp,nil,LOCATION_MZONE,0)
+	if chk==0 then return zone>0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zones) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,tp,LOCATION_HAND)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
-	local zones=s.zonefilter(tp)
-	if not e:GetHandler():IsRelateToEffect(e) or zones==0 then return end
-	Duel.SpecialSummon(e:GetHandler(),0,tp,tp,false,false,POS_FACEUP,zones)
+	local c=e:GetHandler()
+	local zones=aux.GetMMZonesPointedTo(tp,nil,LOCATION_MZONE,0)
+	if not c:IsRelateToEffect(e) or zones==0 then return end
+	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zones)
 end

--- a/unofficial/c511600262.lua
+++ b/unofficial/c511600262.lua
@@ -1,5 +1,5 @@
---海晶乙女 マンダリン
---Marincess Mandarin
+--海晶乙女 マンダリン (Anime)
+--Marincess Mandarin (Anime)
 --scripted by Larry126
 local s,id,alias=GetID()
 function s.initial_effect(c)
@@ -20,25 +20,15 @@ s.listed_series={0x12b}
 function s.filter(c)
 	return c:IsFaceup() and c:IsSetCard(0x12b) and c:IsType(TYPE_LINK) and c:IsType(TYPE_MONSTER)
 end
-function s.spzone(tp,g)
-	local zone=0
-	for c in aux.Next(g) do
-		zone=zone|c:GetLinkedZone(tp)
-	end
-	return zone&0x1f
-end
 function s.condition(e,c)
 	if c==nil then return true end
 	local tp=e:GetHandlerPlayer()
 	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,0,nil)
-	local zone=s.spzone(tp,g)
-	return #g>1 and zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
+	local zone=aux.GetMMZonesPointedTo(tp,Card.IsSetCard,LOCATION_MZONE,0,nil,0x12b)
+	return #g>1 and zone>0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 end
 function s.spval(e,c)
-	local tp=e:GetHandlerPlayer()
-	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,0,nil)
-	local zone=s.spzone(tp,g)
-	return 0,zone
+	return 0,aux.GetMMZonesPointedTo(e:GetHandlerPlayer(),Card.IsSetCard,LOCATION_MZONE,0,nil,0x12b)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp,c)
 	local e1=Effect.CreateEffect(c)

--- a/unofficial/c511600311.lua
+++ b/unofficial/c511600311.lua
@@ -35,25 +35,13 @@ end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil)
 end
-function s.lkfilter(c)
-	return c:IsFaceup() and c:IsType(TYPE_LINK)
-end
-function s.zonefilter(tp)
-	local lg=Duel.GetMatchingGroup(s.lkfilter,tp,LOCATION_MZONE,0,nil)
-	local zone=0
-	for tc in aux.Next(lg) do
-		zone=zone|tc:GetLinkedZone()
-	end 
-	return zone
-end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local zones=s.zonefilter(tp)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zones) end
+	local zones=aux.GetMMZonesPointedTo(tp,nil,LOCATION_MZONE,0)
+	if chk==0 then return zones>0 and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zones) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,tp,LOCATION_HAND)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
-	local zones=s.zonefilter(tp)
+	local zones=aux.GetMMZonesPointedTo(tp,nil,LOCATION_MZONE,0)
 	if not e:GetHandler():IsRelateToEffect(e) or zones==0 then return end
 	Duel.SpecialSummon(e:GetHandler(),0,tp,tp,false,false,POS_FACEUP,zones)
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1705,14 +1705,14 @@ include Link Spells then use LOCATION_ONFIELD, or LOCATION_SZONE to exclude Link
 - "target_player" defaults to "player" if not provided.
 - Any additional parameters that "by_filter" might need can be passed to this function as "..." after "target_player".
 --]]
-function s.link_card_filter(c,f,...)
+local function link_card_filter(c,f,...)
 	return c:IsFaceup() and c:IsType(TYPE_LINK) and (not f or f(c,...))
 end
 function Auxiliary.GetMMZonesPointedTo(player,by_filter,player_location,oppo_location,target_player,...)
 	local loc1=player_location==nil and LOCATION_MZONE or player_location
 	local loc2=oppo_location==nil and loc1 or oppo_location
 	target_player=target_player==nil and player or target_player
-	return Duel.GetMatchingGroup(s.link_card_filter,player,loc1,loc2,nil,by_filter,...):GetLinkedZone(target_player)&0x1f
+	return Duel.GetMatchingGroup(link_card_filter,player,loc1,loc2,nil,by_filter,...):GetLinkedZone(target_player)&0x1f
 end
 
 Duel.LoadScript("cards_specific_functions.lua")

--- a/utility.lua
+++ b/utility.lua
@@ -1692,6 +1692,29 @@ function Auxiliary.CheckPendulumZones(player)
 	return Duel.CheckLocation(player,LOCATION_PZONE,0) or Duel.CheckLocation(player,LOCATION_PZONE,1)
 end
 
+--[[
+Returns the zone values (bitfield mask) of the Main Monster Zones on the field of "target_player"
+that any Link Cards, which match the "by_filter" function/filter, in the locations "player_location"
+and "oppo_location", from the perspective of "player", point to.
+
+- The first parameter, "player", is mandatory, all other parameters are optional, to use the default value of a parameter just pass it as nil.
+- The filter by default checks that the card is face-up and is a Link Card, any additional check (e.g. archetype) is added onto that.
+- Both locations default to LOCATION_MZONE if not provided since most cards care about zones that any Link Monster points to, if you want to
+include Link Spells then use LOCATION_ONFIELD, or LOCATION_SZONE to exclude Link Monsters and check for Link Spells only.
+- The second location defaults to the first one if not provided, if you want to not count a side of the field then you need to specifically pass 0 for that location.
+- "target_player" defaults to "player" if not provided.
+- Any additional parameters that "by_filter" might need can be passed to this function as "..." after "target_player".
+--]]
+function s.link_card_filter(c,f,...)
+	return c:IsFaceup() and c:IsType(TYPE_LINK) and (not f or f(c,...))
+end
+function Auxiliary.GetMMZonesPointedTo(player,by_filter,player_location,oppo_location,target_player,...)
+	local loc1=player_location==nil and LOCATION_MZONE or player_location
+	local loc2=oppo_location==nil and loc1 or oppo_location
+	target_player=target_player==nil and player or target_player
+	return Duel.GetMatchingGroup(s.link_card_filter,player,loc1,loc2,nil,by_filter,...):GetLinkedZone(target_player)&0x1f
+end
+
 Duel.LoadScript("cards_specific_functions.lua")
 Duel.LoadScript("proc_fusion.lua")
 Duel.LoadScript("proc_fusion_spell.lua")


### PR DESCRIPTION
Added a new auxiliary function, "Auxiliary.GetMMZonesPointedTo" (see the comments above the function for how it works).

Updated cards to use this function instead of manually having to mask a player's linked zones to only get the Main Monster Zones, while at the same time fixing some cards that need zones pointed to by a Link Monster and were also working with Link Spells up until now ("Judgment Arrows").

Some cards also received general small fixes and script polishing.