### PR TITLE
Fusion Summoning procedure cancelling update 

### DIFF
--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -308,7 +308,8 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 	sumpos = sumpos or POS_FACEUP
 	return	function(e,tp,eg,ep,ev,re,r,rp)
 				location=location or LOCATION_EXTRA
-				chkf = (chkf and chkf|tp or tp)|FUSPROC_CANCELABLE
+				chkf = chkf and chkf|tp or tp
+				if not preselect then chkf=chkf|FUSPROC_CANCELABLE end
 				local sumlimit=(chkf&(FUSPROC_NOTFUSION|FUSPROC_NOLIMIT))~=0
 				local notfusion=(chkf&FUSPROC_NOTFUSION)~=0
 				if not value then value=0 end

--- a/proc_fusion_spell.lua
+++ b/proc_fusion_spell.lua
@@ -308,7 +308,7 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 	sumpos = sumpos or POS_FACEUP
 	return	function(e,tp,eg,ep,ev,re,r,rp)
 				location=location or LOCATION_EXTRA
-				chkf = chkf and chkf|tp or tp
+				chkf = (chkf and chkf|tp or tp)|FUSPROC_CANCELABLE
 				local sumlimit=(chkf&(FUSPROC_NOTFUSION|FUSPROC_NOLIMIT))~=0
 				local notfusion=(chkf&FUSPROC_NOTFUSION)~=0
 				if not value then value=0 end
@@ -413,17 +413,35 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 				end
 				if #sg1>0 then
 					local sg=sg1:Clone()
-					Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-					local tc=sg:Select(tp,1,1,nil):GetFirst()
-					if preselect and preselect(e,tc)==false then
-						return
-					end
-					local sel=effswithgroup[Fusion.ChainMaterialPrompt(effswithgroup,tc:GetCardID(),tp,e)]
+					local mat1=Group.CreateGroup()
+					local sel=nil
 					local backupmat=nil
+					local tc=nil
+					local ce=nil
+					while #mat1==0 do
+						Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+						tc=sg:Select(tp,1,1,nil):GetFirst()
+						if preselect and preselect(e,tc)==false then
+							return
+						end
+						sel=effswithgroup[Fusion.ChainMaterialPrompt(effswithgroup,tc:GetCardID(),tp,e)]
+						if sel[1]==e then
+							Fusion.CheckAdditional=checkAddition
+							Fusion.ExtraGroup=extragroup
+							mat1=Duel.SelectFusionMaterial(tp,tc,mg1,gc,chkf)
+						else
+							ce=sel[1]
+							local fcheck=nil
+							if ce:GetLabelObject() then fcheck=ce:GetLabelObject():GetOperation() end
+							Fusion.CheckAdditional=checkAddition
+							if fcheck then
+								if checkAddition then Fusion.CheckAdditional=aux.AND(checkAddition,fcheck) else Fusion.CheckAdditional=fcheck end
+							end
+							Fusion.ExtraGroup=ce:GetTarget()(ce,e,tp,value)
+							mat1=Duel.SelectFusionMaterial(tp,tc,Fusion.ExtraGroup,gc,chkf)
+						end
+					end
 					if sel[1]==e then
-						Fusion.CheckAdditional=checkAddition
-						Fusion.ExtraGroup=extragroup
-						local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,gc,chkf)
 						Fusion.ExtraGroup=nil
 						backupmat=mat1:Clone()
 						tc:SetMaterial(mat1)
@@ -506,18 +524,9 @@ function (fusfilter,matfilter,extrafil,extraop,gc2,stage2,exactcount,value,locat
 						Duel.BreakEffect()
 						Duel.SpecialSummonStep(tc,value,tp,tp,sumlimit,false,sumpos)
 					else
-						local ce=sel[1]
-						local fcheck=nil
-						if ce:GetLabelObject() then fcheck=ce:GetLabelObject():GetOperation() end
-						Fusion.CheckAdditional=checkAddition
-						if fcheck then
-							if checkAddition then Fusion.CheckAdditional=aux.AND(checkAddition,fcheck) else Fusion.CheckAdditional=fcheck end
-						end
-						Fusion.ExtraGroup=ce:GetTarget()(ce,e,tp,value)
-						local mat2=Duel.SelectFusionMaterial(tp,tc,Fusion.ExtraGroup,gc,chkf)
 						Fusion.CheckAdditional=nil
 						Fusion.ExtraGroup=nil
-						ce:GetOperation()(sel[1],e,tp,tc,mat2,value,nil,sumpos)
+						ce:GetOperation()(sel[1],e,tp,tc,mat1,value,nil,sumpos)
 						backupmat=tc:GetMaterial():Clone()
 					end
 					stage2(e,tc,tp,backupmat,0)

--- a/skill/c300302001.lua
+++ b/skill/c300302001.lua
@@ -1,7 +1,7 @@
 --Fusion Party!
 local s,id=GetID()
 function s.initial_effect(c)
-	aux.AddSkillProcedure(c,1,false,s.flipcon(Fusion.SummonEffTG()),s.flipop(Fusion.SummonEffOP{preselect=s.preselect}),1)
+	aux.AddSkillProcedure(c,1,false,s.flipcon(Fusion.SummonEffTG()),s.flipop(Fusion.SummonEffOP{extraop=s.extraop}),1)
 end
 function s.flipcon(fustg)
 	return function(e,tp,eg,ep,ev,re,r,rp)
@@ -11,7 +11,7 @@ function s.flipcon(fustg)
 		return aux.CanActivateSkill(tp) and fustg(e,tp,eg,ep,ev,re,r,rp,0)
 	end
 end
-function s.preselect(e,tc)
+function s.extraop(e,tc,tp,mat)
 	return tc:RegisterEffect(e:GetLabelObject())
 end
 function s.flipop(fusop)

--- a/unofficial/c511003010.lua
+++ b/unofficial/c511003010.lua
@@ -3,7 +3,7 @@
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
-	local e1=Fusion.CreateSummonEff{handler=c,matfilter=Fusion.OnFieldMat,extrafil=s.fextra,extratg=s.extratg,exactcount=2,preselect=s.preselect}
+	local e1=Fusion.CreateSummonEff{handler=c,matfilter=Fusion.OnFieldMat,extrafil=s.fextra,extratg=s.extratg,exactcount=2,extraop=s.extraop}
 	e1:SetHintTiming(0,TIMINGS_CHECK_MONSTER_E)
 	e1:SetCost(s.cost)
 	c:RegisterEffect(e1)
@@ -26,7 +26,7 @@ function s.extratg(e,tp,eg,ep,ev,re,r,rp,chk)
 		Duel.SetChainLimit(aux.FALSE)
 	end
 end
-function s.preselect(e,tc)
+function s.extraop(e,tc,tp,mat)
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)


### PR DESCRIPTION
With the addition of https://github.com/ProjectIgnis/CardScripts/commit/1c369cb55c5ad539df704a906abb2e2060b1058f, the player can now cancel selection of the Fusion Materials and go back to selecting which Fusion Monster they want to summon with the effect.