### PR TITLE
fixed Tiger Sabre and Ghost Vicious

### DIFF
--- a/rush/c160011033.lua
+++ b/rush/c160011033.lua
@@ -23,7 +23,7 @@ end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,500) end
 end
-function s.filter(c)
+function s.filter2(c)
 	return c:IsFaceup() and c:IsLevel(5) and c:IsRace(RACE_ZOMBIE) and c:GetEffectCount(EFFECT_EXTRA_ATTACK)==0
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/rush/c160011033.lua
+++ b/rush/c160011033.lua
@@ -23,8 +23,11 @@ end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckLPCost(tp,500) end
 end
+function s.filter(c)
+	return c:IsFaceup() and c:IsLevel(5) and c:IsRace(RACE_ZOMBIE) and c:GetEffectCount(EFFECT_EXTRA_ATTACK)==0
+end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter2,tp,LOCATION_MZONE,0,1,nil) end
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	--Requirement

--- a/rush/c160011058.lua
+++ b/rush/c160011058.lua
@@ -30,7 +30,8 @@ function s.eqlimit(e,c)
     return c:IsFaceup()
 end
 function s.otfilter(c,tp)
-	return c:IsDoubleTribute(FLAG_DOUBLE_TRIB) and (c:IsControler(tp) or c:IsFaceup())
+	local eg=c:GetEquipGroup()
+	return c:IsDoubleTribute(FLAG_DOUBLE_TRIB) and #eg>0 and eg:IsExists(Card.IsCode,1,nil,id) and (c:IsControler(tp) or c:IsFaceup())
 end
 function s.eftg(e,c)
 	return c:IsLevelAbove(7) and c:IsSummonableCard()


### PR DESCRIPTION
- Tiger Sabre should only treat monster that are still equipped with it as Double Tribute
- Ghost Vicious cannot apply its effect to something that can already attack twice