### PR TITLE
fixed Cyber Entry

### DIFF
--- a/rush/c160205029.lua
+++ b/rush/c160205029.lua
@@ -44,7 +44,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CANNOT_ATTACK)
 	e1:SetTargetRange(LOCATION_MZONE,0)
-	e1:SetTarget(function(_,c) return not (c:IsRace(RACE_MACHINE) or c:IsAttribute(ATTRIBUTE_LIGHT)) end)
+	e1:SetTarget(function(_,c) return not (c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_LIGHT)) end)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
 end


### PR DESCRIPTION
Prevents monsters that only fulfill one condition from attacking the turn it is used.