### PR TITLE
Fix Negate Attack (Anime)

### DIFF
--- a/unofficial/c511004341.lua
+++ b/unofficial/c511004341.lua
@@ -4,6 +4,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_ATTACK_ANNOUNCE)

--- a/unofficial/c511004341.lua
+++ b/unofficial/c511004341.lua
@@ -1,21 +1,29 @@
 --攻撃の無力化 (Anime)
---Negate Attack (anime)
---scripted by andré
+--Negate Attack (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
-	--negate atack
+	--Activate
 	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
 	e1:SetCondition(s.condition)
-	e1:SetOperation(s.operation)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 end
-function s.condition(e,tp,ev,eg,ep,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+function s.condition(e,tp,eg,ep,ev,re,r,rp)
+	return tp~=Duel.GetTurnPlayer()
 end
-function s.operation(e,tp,ev,eg,ep,re,r,rp)
-	if Duel.NegateAttack() then
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function s.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetAttacker()
+	if tc:IsRelateToEffect(e) and Duel.NegateAttack() then
 		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE_STEP,1)
 	end
 end


### PR DESCRIPTION
This card's text is the same as the text from its 1st OCG printing, so I updated it to function the same as the OCG card.

https://yugipedia.com/wiki/Negate_Attack_(later_DM_anime)

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).