### PR TITLE
Fix some destruction replacement effects

### DIFF
--- a/official/c14812471.lua
+++ b/official/c14812471.lua
@@ -22,6 +22,7 @@ function s.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 	e2:SetCode(EFFECT_DESTROY_REPLACE)
 	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,{id,1})
 	e2:SetTarget(s.reptg)
 	e2:SetValue(s.repval)
 	e2:SetOperation(s.repop)
@@ -55,17 +56,14 @@ function s.repfilter(c,tp)
 		and not c:IsReason(REASON_REPLACE) and c:IsReason(REASON_EFFECT+REASON_BATTLE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFlagEffect(tp,id)==0 and e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,1)
-		return true
-	else
-		return false
-	end
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c14812471.lua
+++ b/official/c14812471.lua
@@ -57,8 +57,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c14812471.lua
+++ b/official/c14812471.lua
@@ -58,7 +58,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c29280589.lua
+++ b/official/c29280589.lua
@@ -1,6 +1,6 @@
 --エッジインプ・サイズ
 --Edge Imp Scythe
---scripted by Naim
+--Scripted by Naim
 local s,id=GetID()
 function s.initial_effect(c)
 	--Fusion summon from hand
@@ -43,17 +43,14 @@ function s.repfilter(c,tp)
 		and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFlagEffect(tp,id)==0 and e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,1)
-		return true
-	else
-		return false
-	end
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c29280589.lua
+++ b/official/c29280589.lua
@@ -44,8 +44,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c29280589.lua
+++ b/official/c29280589.lua
@@ -45,7 +45,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c31123642.lua
+++ b/official/c31123642.lua
@@ -84,13 +84,14 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:IsAbleToRemove() and not c:IsStatus(STATUS_DESTROY_CONFIRMED)
-		and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c31123642.lua
+++ b/official/c31123642.lua
@@ -86,7 +86,7 @@ function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
 		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c31123642.lua
+++ b/official/c31123642.lua
@@ -85,7 +85,6 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
-		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
 		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end

--- a/official/c33945211.lua
+++ b/official/c33945211.lua
@@ -67,7 +67,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c33945211.lua
+++ b/official/c33945211.lua
@@ -66,8 +66,7 @@ function s.repfilter(c,tp)
 		and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c33945211.lua
+++ b/official/c33945211.lua
@@ -33,12 +33,12 @@ function s.initial_effect(c)
 	e3:SetTarget(s.atktg)
 	e3:SetOperation(s.atkop)
 	c:RegisterEffect(e3)
-end 
+end
+s.listed_series={0x12b} 
 function s.cfilter(c,tp)
 	return c:IsSetCard(0x12b) and c:IsTrap()
 		and c:IsAbleToRemoveAsCost() and Duel.IsExistingMatchingCard(s.thfilter,tp,LOCATION_DECK,0,1,nil,c:GetCode())
 end
-s.listed_series={0x12b}
 function s.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_GRAVE,0,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
@@ -61,17 +61,17 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 	end
 end
-function s.filter(c,tp)
+function s.repfilter(c,tp)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
 		and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741)
-		and eg:IsExists(s.filter,1,nil,tp) and e:GetHandler():IsAbleToRemove() end
-	return Duel.SelectYesNo(tp,aux.Stringid(id,2))
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
-	return s.filter(c,e:GetHandlerPlayer())
+	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)

--- a/official/c33945211.lua
+++ b/official/c33945211.lua
@@ -66,6 +66,7 @@ function s.repfilter(c,tp)
 		and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
 	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end

--- a/official/c33964637.lua
+++ b/official/c33964637.lua
@@ -82,7 +82,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c33964637.lua
+++ b/official/c33964637.lua
@@ -81,8 +81,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c33964637.lua
+++ b/official/c33964637.lua
@@ -1,5 +1,5 @@
 --影六武衆－リハン
---Shadow Six Samurai – Rihan
+--Secret Six Samurai - Rihan
 local s,id=GetID()
 function s.initial_effect(c)
 	--Fusion procedure
@@ -80,13 +80,14 @@ function s.repfilter(c,tp)
 		and c:IsOnField() and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741) and e:GetHandler():IsAbleToRemove()
-		and eg:IsExists(s.repfilter,1,nil,tp) end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c36346532.lua
+++ b/official/c36346532.lua
@@ -82,7 +82,7 @@ function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
 		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c36346532.lua
+++ b/official/c36346532.lua
@@ -81,7 +81,6 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
-		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
 		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end

--- a/official/c36346532.lua
+++ b/official/c36346532.lua
@@ -79,12 +79,15 @@ function s.repfilter(c,tp)
 		and not c:IsReason(REASON_REPLACE) and c:IsReason(REASON_EFFECT)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c44686185.lua
+++ b/official/c44686185.lua
@@ -61,8 +61,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c44686185.lua
+++ b/official/c44686185.lua
@@ -1,8 +1,8 @@
 --影六武衆－ハツメ
---Shadow Six Samurai – Hatsume
+--Secret Six Samurai - Hatsume
 local s,id=GetID()
 function s.initial_effect(c)
-	--special summon
+	--Special Summon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -56,17 +56,18 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.repfilter(c,tp)
-	return c:IsFaceup() and c:IsSetCard(0x3d)
-		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
+	return c:IsFaceup() and c:IsSetCard(0x3d) and c:IsLocation(LOCATION_MZONE)
+		and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741) and e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
-		and #eg==1 end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c44686185.lua
+++ b/official/c44686185.lua
@@ -62,7 +62,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c45154513.lua
+++ b/official/c45154513.lua
@@ -1,5 +1,5 @@
 --アルグールマゼラ
---Al Ghoul Mazera
+--Alghoul Mazera
 --Logical Nonsense
 
 --Substitute ID
@@ -29,19 +29,19 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 	--If your Zombie monster(s) would be destroyed by battle or effect
-function s.filter(c,tp)
+function s.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsRace(RACE_ZOMBIE)
 		and c:IsReason(REASON_BATTLE+REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 	--Activation legality
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741)
-		and eg:IsExists(s.filter,1,nil,tp) and c:IsAbleToRemove() end
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
-	return s.filter(c,e:GetHandlerPlayer())
+	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)

--- a/official/c45154513.lua
+++ b/official/c45154513.lua
@@ -37,7 +37,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c45154513.lua
+++ b/official/c45154513.lua
@@ -36,8 +36,7 @@ end
 	--Activation legality
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c46261704.lua
+++ b/official/c46261704.lua
@@ -71,8 +71,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c46261704.lua
+++ b/official/c46261704.lua
@@ -70,12 +70,14 @@ function s.repfilter(c,tp)
 		and (c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp))
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c46261704.lua
+++ b/official/c46261704.lua
@@ -72,7 +72,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c50185950.lua
+++ b/official/c50185950.lua
@@ -1,4 +1,5 @@
 --サクリボー
+--Relinkuriboh
 local s,id=GetID()
 function s.initial_effect(c)
 	--draw
@@ -31,17 +32,18 @@ function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.Draw(p,d,REASON_EFFECT)
 end
-function s.filter(c,tp)
+function s.repfilter(c,tp)
 	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
 		and c:IsReason(REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741) 
-		and eg:IsExists(s.filter,1,nil,tp) and e:GetHandler():IsAbleToRemove() end
-	return Duel.SelectYesNo(tp,aux.Stringid(id,1))
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
-	return s.filter(c,e:GetHandlerPlayer())
+	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)

--- a/official/c50185950.lua
+++ b/official/c50185950.lua
@@ -38,8 +38,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c50185950.lua
+++ b/official/c50185950.lua
@@ -39,7 +39,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c54320860.lua
+++ b/official/c54320860.lua
@@ -27,17 +27,19 @@ function s.spcon(e,c)
 	return Duel.GetFieldGroupCount(c:GetControler(),LOCATION_HAND,0)==1
 		and Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
 end
-function s.filter(c,tp)
+function s.repfilter(c,tp)
 	return c:IsFaceup() and c:IsControler(tp) and c:IsLocation(LOCATION_MZONE)
 		and c:IsSetCard(0xb) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741) and Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)==0
-		and eg:IsExists(s.filter,1,nil,tp) and e:GetHandler():IsAbleToRemove() end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)==0 end
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
-	return s.filter(c,e:GetHandlerPlayer())
+	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)

--- a/official/c54320860.lua
+++ b/official/c54320860.lua
@@ -33,9 +33,8 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
-		and Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)==0 end
+	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)==0
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c55990317.lua
+++ b/official/c55990317.lua
@@ -62,7 +62,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c55990317.lua
+++ b/official/c55990317.lua
@@ -1,5 +1,5 @@
 --神碑の翼フギン
---Huginn, Wings of the Mysterune
+--Hugin the Runick Wings
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
@@ -61,18 +61,15 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,c,tp) and not eg:IsContains(c) end
-	if Duel.SelectEffectYesNo(tp,c,96) then
-		return true
-	else
-		return false
-	end
+	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
-	return c~=e:GetHandler() and s.repfilter(c,e:GetHandlerPlayer())
+	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end
 function s.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return (r&REASON_EFFECT+REASON_BATTLE)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)

--- a/official/c5846183.lua
+++ b/official/c5846183.lua
@@ -64,17 +64,15 @@ function s.repfilter(c,tp)
 		and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToRemove() and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED)
-		and eg:IsExists(s.repfilter,1,nil,tp) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		return true
-	else
-		return false
-	end
+	local c=e:GetHandler()
+	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c5846183.lua
+++ b/official/c5846183.lua
@@ -66,7 +66,6 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
-		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
 		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end

--- a/official/c5846183.lua
+++ b/official/c5846183.lua
@@ -67,7 +67,7 @@ function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
 		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c6579928.lua
+++ b/official/c6579928.lua
@@ -1,5 +1,5 @@
 --影六武衆－キザル
---Shadow Six Samurai – Kizaru
+--Secret Six Samurai - Kizaru
 local s,id=GetID()
 function s.initial_effect(c)
 	--draw
@@ -46,13 +46,14 @@ function s.repfilter(c,tp)
 		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741) and e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
-		and #eg==1 end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c6579928.lua
+++ b/official/c6579928.lua
@@ -48,7 +48,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c6579928.lua
+++ b/official/c6579928.lua
@@ -47,8 +47,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c66733743.lua
+++ b/official/c66733743.lua
@@ -51,7 +51,6 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
-		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
 		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end

--- a/official/c66733743.lua
+++ b/official/c66733743.lua
@@ -52,7 +52,7 @@ function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
 		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c66733743.lua
+++ b/official/c66733743.lua
@@ -49,17 +49,15 @@ function s.repfilter(c,tp)
 		and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFlagEffect(tp,id)==0 and e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,1)
-		return true
-	else
-		return false
-	end
+	local c=e:GetHandler()
+	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c70180284.lua
+++ b/official/c70180284.lua
@@ -55,7 +55,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c70180284.lua
+++ b/official/c70180284.lua
@@ -54,8 +54,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c70180284.lua
+++ b/official/c70180284.lua
@@ -1,5 +1,5 @@
 --影六武衆-ドウジ
---Shadow Six Samurai - Douji
+--Secret Six Samurai - Doji
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
@@ -53,13 +53,14 @@ function s.repfilter(c,tp)
 		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
-		and #eg==1 end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c70458081.lua
+++ b/official/c70458081.lua
@@ -31,8 +31,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c70458081.lua
+++ b/official/c70458081.lua
@@ -1,4 +1,5 @@
 --EMジンライノ
+--Peformapal Thunderhino
 local s,id=GetID()
 function s.initial_effect(c)
 	--cannot be battle target
@@ -29,13 +30,14 @@ function s.repfilter(c,tp)
 		and c:IsControler(tp) and not c:IsReason(REASON_REPLACE) and c:IsReason(REASON_EFFECT+REASON_BATTLE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741) 
-		and e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c70458081.lua
+++ b/official/c70458081.lua
@@ -32,7 +32,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c71207871.lua
+++ b/official/c71207871.lua
@@ -1,5 +1,5 @@
 --影六武衆-フウマ
---Shadow Six Samurai - Fuhma
+--Secret Six Samurai - Fuma
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
@@ -49,14 +49,14 @@ function s.repfilter(c,tp)
 		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
-	and #eg==1
-	end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c71207871.lua
+++ b/official/c71207871.lua
@@ -50,8 +50,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c71207871.lua
+++ b/official/c71207871.lua
@@ -51,7 +51,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c7291576.lua
+++ b/official/c7291576.lua
@@ -1,5 +1,5 @@
 --影六武衆－ゲンバ
---Shadow Six Samurai – Genba
+--Secret Six Samurai - Genba
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
@@ -45,13 +45,14 @@ function s.repfilter(c,tp)
 		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
-		and #eg==1 end
-	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c7291576.lua
+++ b/official/c7291576.lua
@@ -47,7 +47,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c7291576.lua
+++ b/official/c7291576.lua
@@ -46,8 +46,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and #eg==1 end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/official/c86784733.lua
+++ b/official/c86784733.lua
@@ -1,6 +1,6 @@
 --サイバース・シンクロン
 --Cyberse Synchron
---scripted by Logical Nonsense
+--Scripted by Logical Nonsense
 --Substitute ID
 local s,id=GetID()
 function s.initial_effect(c)
@@ -49,15 +49,15 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 end
 	--Check for your monster in EMZ
 function s.repfilter(c,tp)
-	return  c:IsLocation(LOCATION_MZONE)  and c:GetSequence()>=5 and c:IsControler(tp)
+	return  c:IsLocation(LOCATION_MZONE) and c:GetSequence()>=5 and c:IsControler(tp)
 		and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 	--Activation legality
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) and Duel.GetFlagEffect(tp,id)==0 end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then 
-		Duel.RegisterFlagEffect(tp,id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
-	return true end
+	local c=e:GetHandler()
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 	--
 function s.repval(e,c)
@@ -65,6 +65,5 @@ function s.repval(e,c)
 end
 	--Substutite destruction
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end
-

--- a/official/c86784733.lua
+++ b/official/c86784733.lua
@@ -56,7 +56,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 	--

--- a/official/c86784733.lua
+++ b/official/c86784733.lua
@@ -55,8 +55,7 @@ end
 	--Activation legality
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 	--

--- a/official/c91646304.lua
+++ b/official/c91646304.lua
@@ -35,7 +35,6 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
-		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
 		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end

--- a/official/c91646304.lua
+++ b/official/c91646304.lua
@@ -33,14 +33,11 @@ function s.repfilter(c,tp)
 		and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFlagEffect(tp,id)==0 and e:GetHandler():IsAbleToRemove()
-		and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED) and eg:IsExists(s.repfilter,1,nil,tp) end
-	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
-		Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,1)
-		return true
-	else
-		return false
-	end
+	local c=e:GetHandler()
+	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
+		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())

--- a/official/c91646304.lua
+++ b/official/c91646304.lua
@@ -42,5 +42,5 @@ function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end

--- a/official/c91646304.lua
+++ b/official/c91646304.lua
@@ -36,7 +36,7 @@ function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
 		and not (c:IsLocation(LOCATION_GRAVE) and Duel.IsPlayerAffectedByEffect(tp,69832741))
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/pre-release/c101112001.lua
+++ b/pre-release/c101112001.lua
@@ -72,8 +72,7 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/pre-release/c101112001.lua
+++ b/pre-release/c101112001.lua
@@ -73,7 +73,7 @@ end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
-		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)

--- a/pre-release/c101112001.lua
+++ b/pre-release/c101112001.lua
@@ -10,7 +10,7 @@ function s.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetProperty(EFFECT_FLAG_DELAY)
 	e1:SetCode(EVENT_BE_MATERIAL)
-	e1:SetCountLimit(1,{id,0})
+	e1:SetCountLimit(1,id)
 	e1:SetCondition(s.spcon)
 	e1:SetCost(s.spcost)
 	e1:SetTarget(s.sptg)
@@ -72,14 +72,13 @@ function s.repfilter(c,tp)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
-	if Duel.SelectEffectYesNo(tp,c,96) then
-		return true
-	end
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,69832741)
+		and c:IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp)
+	return Duel.SelectEffectYesNo(tp,c,96)
 end
 function s.repval(e,c)
 	return s.repfilter(c,e:GetHandlerPlayer())
 end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT+REASON_REPLACE)
 end


### PR DESCRIPTION
Touched the monsters that, banish themselves to prevent the destruction of other cards
- Removed unnecessary HOPT flags
- Added missing REASON_REPLACE
- Use string 96 instead of card entry's own strings
- Generic formatting