### PR TITLE
Update cards using EFFECT_TRAP_ACT_IN_HAND and EFFECT_QP_ACT_IN_NTPHAND

### DIFF
--- a/official/c23002292.lua
+++ b/official/c23002292.lua
@@ -17,16 +17,19 @@ function s.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_TRAP_ACT_IN_HAND)
 	e2:SetDescription(aux.Stringid(id,2))
+	e2:SetValue(function(e,c) e:SetLabel(1) end)
 	c:RegisterEffect(e2)
+	e1:SetLabelObject(e2)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return rp~=tp and re:IsHasType(EFFECT_TYPE_ACTIVATE)
 		and re:IsActiveType(TYPE_TRAP) and Duel.IsChainNegatable(ev)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	if e:GetHandler():IsStatus(STATUS_ACT_FROM_HAND) then
-		Duel.PayLPCost(tp,math.floor(Duel.GetLP(tp)/2))
+	if chk==0 then e:GetLabelObject():SetLabel(0) return true end
+	if e:GetLabelObject():GetLabel()>0 then
+		e:GetLabelObject():SetLabel(0)
+		Duel.PayLPCost(tp,Duel.GetLP(tp)//2)
 	end
 end
 function s.setfilter(c)

--- a/official/c74577599.lua
+++ b/official/c74577599.lua
@@ -21,7 +21,10 @@ function s.initial_effect(c)
 	e2:SetCode(EFFECT_TRAP_ACT_IN_SET_TURN)
 	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
 	e2:SetDescription(aux.Stringid(id,2))
+	e2:SetValue(function(e,c) e:SetLabel(1) end)
+	e2:SetCondition(function(e) return Duel.IsExistingMatchingCard(s.spcostfilter,e:GetHandlerPlayer(),LOCATION_HAND,0,1,nil) end)
 	c:RegisterEffect(e2)
+	e1:SetLabelObject(e2)
 	--Special Summon 1 "Traptrix" monster
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(id,1))
@@ -42,9 +45,11 @@ function s.spcostfilter(c)
 	return c:IsNormalTrap() and c:IsDiscardable()
 end
 function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if not e:GetHandler():IsStatus(STATUS_SET_TURN) then return true end
-	if chk==0 then return Duel.IsExistingMatchingCard(s.spcostfilter,tp,LOCATION_HAND,0,1,nil) end
-	Duel.DiscardHand(tp,s.spcostfilter,1,1,REASON_COST+REASON_DISCARD)
+	if chk==0 then e:GetLabelObject():SetLabel(0) return true end
+	if e:GetLabelObject():GetLabel()>0 then
+		e:GetLabelObject():SetLabel(0)
+		Duel.DiscardHand(tp,s.spcostfilter,1,1,REASON_COST+REASON_DISCARD)
+	end
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and e:IsHasType(EFFECT_TYPE_ACTIVATE) 

--- a/official/c85551711.lua
+++ b/official/c85551711.lua
@@ -13,13 +13,11 @@ function s.initial_effect(c)
 	e1:SetTargetRange(LOCATION_HAND,0)
 	e1:SetDescription(aux.Stringid(id,2))
 	e1:SetCondition(s.handcon)
+	e1:SetValue(s.handvalue)
 	c:RegisterEffect(e1)
 	local e2=e1:Clone()
 	e2:SetCode(EFFECT_TRAP_ACT_IN_HAND)
 	c:RegisterEffect(e2)
-	local e3=e1:Clone()
-	e3:SetCode(id)
-	c:RegisterEffect(e3)
 	--activate cost
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_FIELD)
@@ -27,7 +25,6 @@ function s.initial_effect(c)
 	e4:SetRange(LOCATION_MZONE)
 	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e4:SetTargetRange(1,0)
-	e4:SetCost(s.costchk)
 	e4:SetTarget(s.costtg)
 	e4:SetOperation(s.costop)
 	c:RegisterEffect(e4)
@@ -44,17 +41,16 @@ function s.initial_effect(c)
 	c:RegisterEffect(e5)
 end
 function s.handcon(e)
-	return Duel.GetTurnPlayer()~=e:GetHandlerPlayer() and e:GetHandler():GetOverlayCount()~=0
+	local tp=e:GetHandlerPlayer()
+	return Duel.GetTurnPlayer()~=tp and e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT)
+end
+function s.handvalue(e,rc,re)
+	re:GetHandler():RegisterFlagEffect(id,RESET_CHAIN,0,1)
 end
 function s.costtg(e,te,tp)
 	local tc=te:GetHandler()
 	return Duel.GetTurnPlayer()~=e:GetHandlerPlayer()
-		and tc:IsLocation(LOCATION_HAND) and tc:GetEffectCount(id)>0
-		and ((tc:GetEffectCount(EFFECT_QP_ACT_IN_NTPHAND)<=tc:GetEffectCount(id) and tc:IsType(TYPE_QUICKPLAY))
-			or (tc:GetEffectCount(EFFECT_TRAP_ACT_IN_HAND)<=tc:GetEffectCount(id) and tc:IsTrap()))
-end
-function s.costchk(e,te_or_c,tp)
-	return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT)
+		and tc:IsLocation(LOCATION_HAND) and tc:GetFlagEffect(id)>0
 end
 function s.costop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_CARD,0,id)

--- a/unofficial/c511000427.lua
+++ b/unofficial/c511000427.lua
@@ -17,7 +17,8 @@ function s.initial_effect(c)
 	e2:SetCode(EFFECT_QP_ACT_IN_NTPHAND)
 	e2:SetRange(LOCATION_HAND)
 	e2:SetDescription(aux.Stringid(id,0))
-	e2:SetCondition(s.actcon)
+	e2:SetValue(function(e,c) e:SetLabel(1) end)
+	e2:SetCondition(function(e) return Duel.IsExistingMatchingCard(Card.IsDiscardable,e:GetHandlerPlayer(),LOCATION_HAND,0,2,c) end)
 	c:RegisterEffect(e2)
 	e1:SetLabelObject(e2)
 end
@@ -25,31 +26,12 @@ function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(Card.IsPreviousControler,1,nil,tp)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	local c=e:GetHandler()
-	if chk==0 then
-		if c:GetFlagEffect(id)==0 or Duel.IsTurnPlayer(tp) then
-			e:SetLabel(0)
-			return true
-		elseif c:GetFlagEffect(id)>0 and Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,2,c) then
-			e:SetLabel(1)
-			return true
-		end
-	end
-	if e:GetLabel()==1 then
-		e:SetLabel(0)
-		Duel.DiscardHand(tp,Card.IsDiscardable,2,2,REASON_COST+REASON_DISCARD,c)
+	if chk==0 then e:GetLabelObject():SetLabel(0) return true end
+	if e:GetLabelObject():GetLabel()>0 then
+		e:GetLabelObject():SetLabel(0)
+		Duel.DiscardHand(tp,Card.IsDiscardable,2,2,REASON_COST+REASON_DISCARD,e:GetHandler())
 	end
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SkipPhase(Duel.GetTurnPlayer(),PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE_STEP,1)
-end
-function s.actcon(e)
-	local c=e:GetHandler()
-	if Duel.IsExistingMatchingCard(Card.IsDiscardable,e:GetHandlerPlayer(),LOCATION_HAND,0,2,c) then
-		c:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,1)
-		return true
-	else
-		c:ResetFlagEffect(id)
-		return false
-	end
 end


### PR DESCRIPTION
Update Red Reboot, Traptrix Holetaea, Ebon High Magician and Aid to the Doomed that require additional costs if they used such effects to be activated from the hand.