### PR TITLE
Replace magic values with meaninful constant names

### DIFF
--- a/cards_specific_functions.lua
+++ b/cards_specific_functions.lua
@@ -216,7 +216,7 @@ function Auxiliary.MaleficUniqueFilter(cc)
 	t[cc]=true
 	mt.has_malefic_unique=t
 	return 	function(c)
-				return not Duel.IsPlayerAffectedByEffect(c:GetControler(),75223115) and c:IsSetCard(0x23)
+				return not Duel.IsPlayerAffectedByEffect(c:GetControler(),75223115) and c:IsSetCard(SET_MALEFIC)
 			end
 end
 --Procedure for Malefic monsters' Special Summon (includes handling of Malefic Paradox Gear)
@@ -233,7 +233,7 @@ function Auxiliary.AddMaleficSummonProcedure(c,code,loc,excon)
 	c:RegisterEffect(e1)
 end
 function Auxiliary.MaleficSummonFilter(c,cd)
-	return ((cd and c:IsCode(cd)) or (not cd and c:IsSetCard(0x23))) and c:IsAbleToRemoveAsCost()
+	return ((cd and c:IsCode(cd)) or (not cd and c:IsSetCard(SET_MALEFIC))) and c:IsAbleToRemoveAsCost()
 end
 function Auxiliary.MaleficSummonSubstitute(c,cd,tp)
 	return c:IsHasEffect(48829461,tp) and c:IsAbleToRemoveAsCost()
@@ -293,7 +293,7 @@ function Witchcrafter.repcon(e)
 end
 function Witchcrafter.repval(base,e,tp,eg,ep,ev,re,r,rp,chk,extracon)
 	local c=e:GetHandler()
-	return c:IsControler(tp) and c:IsMonster() and c:IsSetCard(0x128)
+	return c:IsControler(tp) and c:IsMonster() and c:IsSetCard(SET_WITCHCRAFTER)
 end
 function Witchcrafter.repop(id)
 	return function(base,e,tp,eg,ep,ev,re,r,rp)
@@ -380,7 +380,7 @@ function Auxiliary.LavaOperation(required,filter)
 	end
 end
 function Auxiliary.AddKaijuProcedure(c)
-	c:SetUniqueOnField(1,0,aux.FilterBoolFunction(Card.IsSetCard,0xd3),LOCATION_MZONE)
+	c:SetUniqueOnField(1,0,aux.FilterBoolFunction(Card.IsSetCard,SET_KAIJU),LOCATION_MZONE)
 	local e1 = aux.AddLavaProcedure(c,1,POS_FACEUP_ATTACK)
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
@@ -396,9 +396,7 @@ function Auxiliary.KaijuCondition(e,c)
 	if c==nil then return true end
 	local tp=c:GetControler()
 	return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(function(c)
-											return c:IsFaceup() and c:IsSetCard(0xd3)
-										end,tp,0,LOCATION_MZONE,1,nil)
+		and Duel.IsExistingMatchingCard(aux.FaceupFunction(Card.IsSetCard,SET_KAIJU),tp,0,LOCATION_MZONE,1,nil)
 end
 function Auxiliary.CheckStealEquip(c,e,tp)
 	if c:IsFacedown() or not c:IsControlerCanBeChanged() or not c:IsControler(1-tp) then return false end
@@ -512,7 +510,7 @@ end
 --(card in the same column as a security force)
 function Auxiliary.SecurityTarget(e,_c)
 	return _c:GetColumnGroup():IsExists(function(c,tp)
-											return c:IsControler(tp) and c:IsFaceup() and c:IsMonster() and c:IsSetCard(0x15a)
+											return c:IsControler(tp) and c:IsFaceup() and c:IsMonster() and c:IsSetCard(SET_S_FORCE)
 										 end,1,_c,e:GetHandlerPlayer())
 end
 
@@ -591,7 +589,7 @@ end
 -- Amazement and Ɐttraction helper functions
 AA = {}
 function AA.eqtgfilter(c,tp)
-	return c:IsFaceup() and (c:IsSetCard(0x15e) or (not c:IsControler(tp)))
+	return c:IsFaceup() and (c:IsSetCard(SET_AMAZEMENT) or (not c:IsControler(tp)))
 end
 function AA.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and AA.eqtgfilter(chkc,tp) end
@@ -647,11 +645,11 @@ function Auxiliary.AttractionEquipCon(self)
 	end
 end
 function AA.eqsfilter(c,tp)
-	return c:IsSetCard(0x15f) and c:IsTrap() and c:GetEquipTarget() and
+	return c:IsSetCard(SET_ATTRACTION) and c:IsTrap() and c:GetEquipTarget() and
 		   Duel.IsExistingMatchingCard(AA.eqmfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,c:GetEquipTarget(),tp)
 end
 function AA.eqmfilter(c,tp)
-	return c:IsFaceup() and (c:IsSetCard(0x15e) or (not c:IsControler(tp)))
+	return c:IsFaceup() and (c:IsSetCard(SET_AMAZEMENT) or (not c:IsControler(tp)))
 end
 function AA.qeqetg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return false end
@@ -687,7 +685,7 @@ end
 -- Description: cost for "Security Force" cards that banish a card from the hand, needed for "Security Force Chase" from LIOV
 local SecurityForce={}
 function SecurityForce.CostFilter(c)
-	return c:IsSetCard(0x15a) and c:IsAbleToRemoveAsCost()
+	return c:IsSetCard(SET_S_FORCE) and c:IsAbleToRemoveAsCost()
 end
 function SecurityForce.Cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(SecurityForce.CostFilter,tp,LOCATION_HAND,0,1,nil) end
@@ -841,7 +839,7 @@ end
 
 Drytron={}
 function Drytron.TributeCostFilter(c,tp)
-	return ((c:IsSetCard(0x151) and c:IsMonster()) or c:IsRitualMonster()) and (c:IsControler(tp) or c:IsFaceup())
+	return ((c:IsSetCard(SET_DRYTRON) and c:IsMonster()) or c:IsRitualMonster()) and (c:IsControler(tp) or c:IsFaceup())
 		and (c:IsInMainMZone(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)>0)
 end
 function Drytron.TributeBaseCost(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -906,8 +904,8 @@ Effect.CreateMysteruneQPEffect = (function()
 	end
 
 	local function spfilter(c,e,tp)
-		return c:IsSetCard(0x180) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-			and Duel.GetLocationCountFromEx(tp,tp,nil,c,0x60)>0
+		return c:IsSetCard(SET_RUNICK) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+			and Duel.GetLocationCountFromEx(tp,tp,nil,c,ONLYEMZONE)>0
 	end
 
 	local function sptg(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -919,7 +917,7 @@ Effect.CreateMysteruneQPEffect = (function()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g=Duel.SelectMatchingCard(tp,spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp)
 		if #g>0 then
-			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP,0x60)
+			Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP,ONLYEMZONE)
 		end
 		skipop(e,tp,eg,ep,ev,re,r,rp)
 	end
@@ -1021,9 +1019,9 @@ end)()
 --[[
 	Effect.CreateVernalizerSPEffect(c,id,desc,uniquecat,uniquetg,uniqueop)
 
-	Creates an ignition Effect object for the "Vernalizer Fairy" effects that
+	Creates an ignition Effect object for the "Vernusylph" effects that
 	discard themselves and another card from the hand.
-	Includes handling for "Flower Crown of the Vernalizer Fairy" cost replacement.
+	Includes handling for "Vernusylph Corolla" cost replacement.
 
 	Card c: the owner of the Effect
 	int id: the card ID used for the HOPT restriction and strings
@@ -1035,10 +1033,10 @@ end)()
 		it can also return an optional passcode (int) which will be excluded from the special summon
 --]]
 Effect.CreateVernalizerSPEffect=(function()
-	local stringbase=9350312 -- use strings from "Hills and Blooms" so they don't need to be stored in every card
+	local stringbase=9350312 -- use strings from "Flourishing Hils" so they don't need to be stored in every card
 
 	local function verncostfilter(c)
-		return (c:IsMonster() or c:IsSetCard(0x183)) and c:IsDiscardable()
+		return (c:IsMonster() or c:IsSetCard(SET_VERNUSYLPH)) and c:IsDiscardable()
 	end
 
 	local function verncost(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -1104,7 +1102,7 @@ function Auxiliary.WelcomeLabrynthTrapDestroyOperation(e,tp)
 	local addeff=Duel.IsPlayerAffectedByEffect(tp,CARD_LABRYNTH_LABYRINTH)
 	if not (addeff and addeff:CheckCountLimit(tp)
 		and e:IsHasType(EFFECT_TYPE_ACTIVATE) and e:GetActiveType()==TYPE_TRAP
-		and c:IsSetCard(0x117f) and not c:IsStatus(STATUS_ACT_FROM_HAND)
+		and c:IsSetCard(SET_WELCOME_LABRYNTH) and not c:IsStatus(STATUS_ACT_FROM_HAND)
 		and Duel.IsExistingMatchingCard(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c)
 		and Duel.SelectYesNo(tp,aux.Stringid(CARD_LABRYNTH_LABYRINTH,1))) then return end
 	addeff:UseCountLimit(tp)
@@ -1147,7 +1145,7 @@ local InfernoidInt={}
 function InfernoidInt.spfilter(c)
 	return c:IsSetCard(SET_INFERNOID) and c:IsMonster() and c:IsAbleToRemoveAsCost() 
 end
-function InfernoidInt.getLocations(c,tp)	
+function InfernoidInt.getLocations(c,tp)
 	local locations=LOCATION_HAND
 	if Duel.IsPlayerAffectedByEffect(tp,69832741) then
 		locations=locations|LOCATION_MZONE

--- a/constant.lua
+++ b/constant.lua
@@ -20,8 +20,9 @@ LOCATION_EMZONE = 0x1000
 --Locations used for redirecting
 LOCATION_DECKBOT = 0x10001
 LOCATION_DECKSHF = 0x20001
---Location used to filter monster zones
-ONLYMMZONE = 0x1f
+--Constants used to filter monster zones
+ZONES_MMZ = 0x1f
+ZONES_EMZ = 0x60
 --Sequences used for SendtoDeck
 SEQ_DECKTOP     = 0
 SEQ_DECKBOTTOM  = 1

--- a/official/c13291886.lua
+++ b/official/c13291886.lua
@@ -50,7 +50,7 @@ end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local zone=(1<<c:GetSequence())&0x1f
+		local zone=(1<<c:GetSequence())&ZONES_MMZ
 		return zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
@@ -58,7 +58,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	local zone=(1<<c:GetSequence())&0x1f
+	local zone=(1<<c:GetSequence())&ZONES_MMZ
 	if zone~=0 then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)
 	end
@@ -116,7 +116,7 @@ function s.ctop(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetDescription(3206)
 		e2:SetCode(EFFECT_CANNOT_ATTACK)
 		tc:RegisterEffect(e2)
-		-- Treated as a "Valiants" monster
+		-- Treated as a "Vaylantz" monster
 		local e3=Effect.CreateEffect(c)
 		e3:SetDescription(aux.Stringid(id,3))
 		e3:SetProperty(EFFECT_FLAG_CLIENT_HINT)

--- a/official/c15130912.lua
+++ b/official/c15130912.lua
@@ -44,7 +44,7 @@ s.listed_series={SET_VAYLANTZ}
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local zone=(1<<c:GetSequence())&0x1f
+		local zone=(1<<c:GetSequence())&ZONES_MMZ
 		return zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
@@ -52,7 +52,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	local zone=(1<<c:GetSequence())&0x1f
+	local zone=(1<<c:GetSequence())&ZONES_MMZ
 	if zone~=0 then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)
 	end

--- a/official/c19882096.lua
+++ b/official/c19882096.lua
@@ -32,5 +32,5 @@ function s.hspval(e,c)
 		left_right=tc:IsInMainMZone() and 1 or 0
 		zone=(zone|tc:GetColumnZone(LOCATION_MZONE,left_right,left_right,tp))
 	end
-	return 0,zone&0x1f
+	return 0,zone&ZONES_MMZ
 end

--- a/official/c34974462.lua
+++ b/official/c34974462.lua
@@ -59,7 +59,7 @@ function s.spcheck(sg,e,tp,mg)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
-		local zone=e:GetHandler():GetLinkedZone(tp)&0x1f
+		local zone=e:GetHandler():GetLinkedZone(tp)&ZONES_MMZ
 		local ct=Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_TOFIELD,zone)
 		local g=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_DECK,0,nil,e,tp,zone)
 		return ct>1 and not Duel.IsPlayerAffectedByEffect(tp,CARD_BLUEEYES_SPIRIT)
@@ -70,7 +70,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) or Duel.IsPlayerAffectedByEffect(tp,CARD_BLUEEYES_SPIRIT) then return end
-	local zone=e:GetHandler():GetLinkedZone(tp)&0x1f
+	local zone=e:GetHandler():GetLinkedZone(tp)&ZONES_MMZ
 	local ct=Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_TOFIELD,zone)
 	local sg=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_DECK,0,nil,e,tp,zone)
 	if #sg==0 then return end

--- a/official/c3567660.lua
+++ b/official/c3567660.lua
@@ -17,7 +17,7 @@ function s.initial_effect(c)
 end
 function s.filter(c,tp)
 	return c:IsFaceup() and c:IsLinkMonster() and c:IsInExtraMZone()
-		and c:GetLink()>0 and Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_CONTROL,c:GetLinkedZone(tp)&0x1f)>0
+		and c:GetLink()>0 and Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_CONTROL,c:GetLinkedZone(tp)&ZONES_MMZ)>0
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and s.filter(chkc,tp) end
@@ -31,7 +31,7 @@ end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if not tc or not tc:IsRelateToEffect(e) or not tc:IsControler(tp) then return end
-	local zone=tc:GetLinkedZone(tp)&0x1f
+	local zone=tc:GetLinkedZone(tp)&ZONES_MMZ
 	if Duel.GetLocationCount(tp,LOCATION_MZONE,tp,LOCATION_REASON_CONTROL,zone)>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOZONE)
 		local nseq=math.log(Duel.SelectDisableField(tp,1,LOCATION_MZONE,LOCATION_MZONE,~zone),2)

--- a/official/c40680521.lua
+++ b/official/c40680521.lua
@@ -60,7 +60,7 @@ end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local zone=(1<<c:GetSequence())&0x1f
+		local zone=(1<<c:GetSequence())&ZONES_MMZ
 		return zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
@@ -68,7 +68,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	local zone=(1<<c:GetSequence())&0x1f
+	local zone=(1<<c:GetSequence())&ZONES_MMZ
 	if zone~=0 then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)
 	end

--- a/official/c41525660.lua
+++ b/official/c41525660.lua
@@ -50,7 +50,7 @@ end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local zone=(1<<c:GetSequence())&0x1f
+		local zone=(1<<c:GetSequence())&ZONES_MMZ
 		return zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
@@ -58,7 +58,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	local zone=(1<<c:GetSequence())&0x1f
+	local zone=(1<<c:GetSequence())&ZONES_MMZ
 	if zone~=0 then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)
 	end
@@ -82,7 +82,7 @@ function s.sspcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.sspfilter(c,e,tp)
 	return c:IsSetCard(SET_VAYLANTZ) and c:IsOriginalType(TYPE_MONSTER) and c:GetSequence()<5
-		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,(1<<c:GetSequence())&0x1f)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,(1<<c:GetSequence())&ZONES_MMZ)
 end
 function s.ssptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_SZONE) and s.sspfilter(chkc,e,tp) end
@@ -94,6 +94,6 @@ end
 function s.sspop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then 
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP,(1<<tc:GetSequence())&0x1f)
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP,(1<<tc:GetSequence())&ZONES_MMZ)
 	end
 end

--- a/official/c46877100.lua
+++ b/official/c46877100.lua
@@ -33,7 +33,7 @@ function s.hspval(e,c)
 		left_right=tc:IsInMainMZone() and 1 or 0
 		zone=(zone|tc:GetColumnZone(LOCATION_MZONE,left_right,left_right,tp))
 	end
-	return 0,zone&0x1f
+	return 0,zone&ZONES_MMZ
 end
 function s.atkval(e)
 	return Duel.GetMatchingGroupCount(Card.IsDefensePos,e:GetHandlerPlayer(),LOCATION_MZONE,0,nil)*300

--- a/official/c49568943.lua
+++ b/official/c49568943.lua
@@ -1,5 +1,5 @@
 --VV-真羅万象
---Valiants Vorld - Shinrabansho
+--Vaylantz Vorld - Shinra Bansho
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
@@ -50,7 +50,7 @@ function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.spfilter(c,e,tp)
 	return c:IsFaceup() and c:IsOriginalType(TYPE_MONSTER) and c:GetSequence()<5
-		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,(1<<c:GetSequence())&0x1f)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,(1<<c:GetSequence())&ZONES_MMZ)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_SZONE) and s.spfilter(chkc,e,tp) end
@@ -62,6 +62,6 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then 
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP,(1<<tc:GetSequence())&0x1f)
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP,(1<<tc:GetSequence())&ZONES_MMZ)
 	end
 end

--- a/official/c50687050.lua
+++ b/official/c50687050.lua
@@ -76,7 +76,7 @@ end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local zone=(1<<c:GetSequence())&0x1f
+		local zone=(1<<c:GetSequence())&ZONES_MMZ
 		return zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
@@ -84,7 +84,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	local zone=(1<<c:GetSequence())&0x1f
+	local zone=(1<<c:GetSequence())&ZONES_MMZ
 	if zone~=0 then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)
 	end

--- a/official/c76075139.lua
+++ b/official/c76075139.lua
@@ -44,12 +44,13 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 s.listed_series={SET_VAYLANTZ}
+local mask=0x2|0x8|0x20|0x40
 function s.splimit(e,se,sp,st)
 	return not e:GetHandler():IsLocation(LOCATION_EXTRA) or aux.fuslimit(e,se,sp,st) or aux.penlimit(e,se,sp,st)
 end
 function s.hspfilter(c,tp,sc)
 	local zone=1<<c:GetSequence()
-	return zone&0x6a==zone and c:IsSetCard(SET_VAYLANTZ) and c:IsLevelAbove(5)
+	return zone&mask==zone and c:IsSetCard(SET_VAYLANTZ) and c:IsLevelAbove(5)
 		and not c:IsType(TYPE_FUSION) and Duel.GetLocationCountFromEx(tp,tp,c,sc)>0
 end
 function s.hspcon(e,c)
@@ -92,7 +93,7 @@ end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local zone=(1<<c:GetSequence())&0x1f
+		local zone=(1<<c:GetSequence())&ZONES_MMZ
 		return zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
@@ -100,7 +101,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	local zone=(1<<c:GetSequence())&0x1f
+	local zone=(1<<c:GetSequence())&ZONES_MMZ
 	if zone~=0 then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)
 	end

--- a/official/c82886276.lua
+++ b/official/c82886276.lua
@@ -37,7 +37,7 @@ function s.tgfilter(c,e,tp)
 		or Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp,c,c:GetLinkedZone(1-tp),1-tp))
 end
 function s.spfilter(c,e,summonPlayer,targetCard,targetCardZones,toFieldPlayer)
-	local zone=(targetCardZones|(c:IsLinkMonster() and targetCard:GetToBeLinkedZone(c,toFieldPlayer) or 0))&ONLYMMZONE
+	local zone=(targetCardZones|(c:IsLinkMonster() and targetCard:GetToBeLinkedZone(c,toFieldPlayer) or 0))&ZONES_MMZ
 	return zone>0 and c:IsCanBeSpecialSummoned(e,0,summonPlayer,false,false,POS_FACEUP,toFieldPlayer,zone)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
@@ -62,7 +62,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 			{b1,aux.Stringid(id,2)},
 			{b2,aux.Stringid(id,3)})
 		local toFieldPlayer=op==1 and tp or 1-tp
-		local zone=(tc:GetLinkedZone(toFieldPlayer)|(sc:IsLinkMonster() and tc:GetToBeLinkedZone(sc,toFieldPlayer) or 0))&ONLYMMZONE
+		local zone=(tc:GetLinkedZone(toFieldPlayer)|(sc:IsLinkMonster() and tc:GetToBeLinkedZone(sc,toFieldPlayer) or 0))&ZONES_MMZ
 		Duel.SpecialSummonStep(sc,0,tp,toFieldPlayer,false,false,POS_FACEUP,zone)
 		g1=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_GRAVE,0,nil,e,tp,tc,tc:GetLinkedZone(tp),tp)
 		g2=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_GRAVE,0,nil,e,tp,tc,tc:GetLinkedZone(1-tp),1-tp)

--- a/official/c83488497.lua
+++ b/official/c83488497.lua
@@ -34,7 +34,7 @@ function s.hspval(e,c)
 		left_right=tc:IsInMainMZone() and 1 or 0
 		zone=(zone|tc:GetColumnZone(LOCATION_MZONE,left_right,left_right,tp))
 	end
-	return 0,zone&0x1f
+	return 0,zone&ZONES_MMZ
 end
 function s.atkcon(e)
 	return Duel.IsExistingMatchingCard(aux.AND(s.sclawfilter,Card.IsDefensePos),e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)

--- a/official/c87897777.lua
+++ b/official/c87897777.lua
@@ -1,5 +1,5 @@
 -- ヴァリアンツＭ－マーキス
--- Vaylantz Mad - Marquis
+-- Vaylantz Mad Marques
 -- Scripted by Hatter
 local s,id=GetID()
 function s.initial_effect(c)
@@ -51,7 +51,7 @@ end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then
-		local zone=(1<<c:GetSequence())&0x1f
+		local zone=(1<<c:GetSequence())&ZONES_MMZ
 		return zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
@@ -59,7 +59,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
-	local zone=(1<<c:GetSequence())&0x1f
+	local zone=(1<<c:GetSequence())&ZONES_MMZ
 	if zone~=0 then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP,zone)
 	end
@@ -92,7 +92,8 @@ function s.sspcon(e,tp,eg,ep,ev,re,r,rp)
 	return c:IsLocation(LOCATION_MZONE) and c:IsPreviousLocation(LOCATION_MZONE)
 end
 function s.sspfilter(c,e,tp)
-	return c:IsOriginalType(TYPE_MONSTER) and c:GetSequence()<5 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,(1<<c:GetSequence())&0x1f)
+	return c:IsOriginalType(TYPE_MONSTER) and c:GetSequence()<5
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,(1<<c:GetSequence())&ZONES_MMZ)
 end
 function s.ssptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.sspfilter,tp,LOCATION_SZONE,0,1,nil,e,tp) end
@@ -107,6 +108,6 @@ function s.sspop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tc=g:Select(tp,1,1,nil):GetFirst()
 	if tc then 
-		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP,(1<<tc:GetSequence())&0x1f)
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP,(1<<tc:GetSequence())&ZONES_MMZ)
 	end
 end

--- a/utility.lua
+++ b/utility.lua
@@ -1099,7 +1099,7 @@ function Auxiliary.dxmcostgen(min,max,op)
 	end
 	return function(e,tp,eg,ep,ev,re,r,rp,chk)
 		local c=e:GetHandler()
-		local nn=c:IsSetCard(0x14b) and c:IsType(TYPE_XYZ) and Duel.IsPlayerAffectedByEffect(tp,CARD_NUMERON_NETWORK)
+		local nn=c:IsSetCard(SET_NUMERON) and c:IsType(TYPE_XYZ) and Duel.IsPlayerAffectedByEffect(tp,CARD_NUMERON_NETWORK)
 		local crm=c:CheckRemoveOverlayCard(tp,min,REASON_COST)
 		if chk==0 then return (nn and c:IsLocation(LOCATION_MZONE)) or crm end
 		if nn and (not crm or Duel.SelectYesNo(tp,aux.Stringid(CARD_NUMERON_NETWORK,1))) then
@@ -2070,7 +2070,7 @@ function Auxiliary.GetMMZonesPointedTo(player,by_filter,player_location,oppo_loc
 	local loc1=player_location==nil and LOCATION_MZONE or player_location
 	local loc2=oppo_location==nil and loc1 or oppo_location
 	target_player=target_player==nil and player or target_player
-	return Duel.GetMatchingGroup(link_card_filter,player,loc1,loc2,nil,by_filter,...):GetLinkedZone(target_player)&0x1f
+	return Duel.GetMatchingGroup(link_card_filter,player,loc1,loc2,nil,by_filter,...):GetLinkedZone(target_player)&ONLYMMZONE
 end
 
 --[[


### PR DESCRIPTION
-Removes magic numbers from the card specific functions and utility
-Update 13 cards that are already in the Delta Puppet repository to use ZONES_MMZ 