### PR TITLE
Resolve token miscount in Kash Big Bang

### DIFF
--- a/official/c33925864.lua
+++ b/official/c33925864.lua
@@ -37,27 +37,34 @@ end
 function s.rmfilter(c,p)
 	return Duel.IsPlayerCanRemove(p,c) and not c:IsType(TYPE_TOKEN)
 end
+function s.rmtkfilter(c,p)
+	return Duel.IsPlayerCanRemove(p,c)
+end
 function s.rmvtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local g1=Duel.GetMatchingGroup(s.rmfilter,tp,LOCATION_MZONE,0,nil,tp)
-	local g2=Duel.GetMatchingGroup(s.rmfilter,tp,0,LOCATION_MZONE,nil,1-tp)
-	if chk==0 then return (#g1>1 and not Duel.IsPlayerAffectedByEffect(tp,30459350))
-		or (#g2>1 and not Duel.IsPlayerAffectedByEffect(1-tp,30459350)) end
+	local g1=Duel.GetMatchingGroup(s.rmtkfilter,tp,LOCATION_MZONE,0,nil,tp)
+	local g2=Duel.GetMatchingGroup(s.rmtkfilter,tp,0,LOCATION_MZONE,nil,1-tp)
+	local g3=Duel.GetMatchingGroup(s.rmfilter,tp,LOCATION_MZONE,0,nil,tp) --Check there are at least 1 non-token monsters
+	local g4=Duel.GetMatchingGroup(s.rmfilter,tp,0,LOCATION_MZONE,nil,1-tp)
+	if chk==0 then return (#g1>1 and #g3>0 and not Duel.IsPlayerAffectedByEffect(tp,30459350))
+		or (#g2>1 and #g4>0 and not Duel.IsPlayerAffectedByEffect(1-tp,30459350)) end
 end
 function s.rmvop(e,tp,eg,ep,ev,re,r,rp)
 	local p1=Duel.GetTurnPlayer() --used to make the turn player banish first
 	local p2=1-Duel.GetTurnPlayer()
-	local g1=Duel.GetMatchingGroup(s.rmfilter,p1,LOCATION_MZONE,0,nil,p1)
-	if not Duel.IsPlayerAffectedByEffect(p1,30459350) and #g1>1 then
-		local ct=#g1-1
+	local g1=Duel.GetMatchingGroup(s.rmtkfilter,p1,LOCATION_MZONE,0,nil,p1)
+	local g2=Duel.GetMatchingGroup(s.rmfilter,p1,LOCATION_MZONE,0,nil,p1)
+	if not Duel.IsPlayerAffectedByEffect(p1,30459350) and #g1>1 and #g2>0 then
+		local ct=math.min(#g1-1,#g2)
 		Duel.Hint(HINT_SELECTMSG,p1,HINTMSG_REMOVE)
-		local sg=g1:FilterSelect(p1,Card.IsAbleToRemove,ct,ct,nil,p1,POS_FACEDOWN,REASON_RULE)
+		local sg=g2:FilterSelect(p1,Card.IsAbleToRemove,ct,ct,nil,p1,POS_FACEDOWN,REASON_RULE)
 		Duel.Remove(sg,POS_FACEDOWN,REASON_RULE)
 	end
-	local g2=Duel.GetMatchingGroup(s.rmfilter,p2,LOCATION_MZONE,0,nil,p2)
-	if not Duel.IsPlayerAffectedByEffect(p2,30459350) and #g2>1 then
-		local ct=#g2-1
+	local g3=Duel.GetMatchingGroup(s.rmtkfilter,p2,LOCATION_MZONE,0,nil,p2)
+	local g4=Duel.GetMatchingGroup(s.rmfilter,p1,LOCATION_MZONE,0,nil,p1)
+	if not Duel.IsPlayerAffectedByEffect(p2,30459350) and #g3>1 and #g4>0 then
+		local ct=math.min(#g3-1,#g4)
 		Duel.Hint(HINT_SELECTMSG,p2,HINTMSG_REMOVE)
-		local sg=g2:FilterSelect(p2,Card.IsAbleToRemove,ct,ct,nil,p2,POS_FACEDOWN,REASON_RULE)
+		local sg=g4:FilterSelect(p2,Card.IsAbleToRemove,ct,ct,nil,p2,POS_FACEDOWN,REASON_RULE)
 		Duel.Remove(sg,POS_FACEDOWN,REASON_RULE)
 	end
 end


### PR DESCRIPTION
Resolving token miscount in Kashtira Big Bang. Currently it doesn't count tokens as existing when performing the banish effect, meaning 1 more card is kept along with the token, when only token(s) should be left. Splitting the token filter off into its own function separate.

Example scenarios:
turn player controls 1 token and 1 monster, big bang should be live, they must banish the monster turn player controls only 2 tokens, big bang should not be able to activate turn player controls 2 tokens and 3 monsters, should be forced to banish 3 monsters, among the non-tokens they control (so all non-token monsters)

<!--
Hello, thanks for submitting a pull request! Please provide enough information so we can review it.

If you are submitting an addition to the unofficial script project, the pull request title should be
of the form `Add "CARD NAME"`. Replace this comment with a Yugipedia link.

If you are submitting a bug fix, the pull request title should be of the form `Fix "CARD NAME"`.
In this case, replace this comment with a brief summary of your change. What did you fix?
--->

- [ ] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).

**New card checklist**

- [ ] I have submitted a corresponding database entry for [BabelCDB](https://github.com/ProjectIgnis/BabelCDB/blob/master/README.md) according to its guidelines. Link to the pull request: _fill in_
- [ ] This card is not marked with a reason to not be added in the unofficial card tracker in `#card-scripting-101`.
Supervising staff member(s): _fill in_
