### PR TITLE
fixed some rush cards

### DIFF
--- a/rush/c160004054.lua
+++ b/rush/c160004054.lua
@@ -22,20 +22,23 @@ end
 function s.costfilter(c)
 	return c:IsRace(RACE_WYRM) and c:IsFaceup() and c:IsAbleToGraveAsCost() and not c:IsMaximumModeSide()
 end
+function s.filter(c)
+	return c:IsFaceup() and c:CanAttack()
+end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil,e,tp) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,0,LOCATION_MZONE,1,nil) end
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	-- requirement
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 	local g=Duel.SelectMatchingCard(tp,s.costfilter,tp,LOCATION_MZONE,0,1,1,nil)
 	g=g:AddMaximumCheck()
-	Duel.HintSelection(g)
+	Duel.HintSelection(g,true)
 	local ct=Duel.SendtoGrave(g,REASON_COST)
 	if ct>0 then
 		--Effect
-		local g=Duel.SelectMatchingCard(tp,Card.IsFaceup,tp,0,LOCATION_MZONE,1,1,nil)
-		Duel.HintSelection(g)
+		local g=Duel.SelectMatchingCard(tp,s.filter,tp,0,LOCATION_MZONE,1,1,nil)
+		Duel.HintSelection(g,true)
 		if #g>0 then
 			--cannot attack
 			local ge2=Effect.CreateEffect(e:GetHandler())

--- a/rush/c160004054.lua
+++ b/rush/c160004054.lua
@@ -2,8 +2,9 @@
 --Mythic Sword Blockade
 local s,id=GetID()
 function s.initial_effect(c)
-	--If opponent normal summons, special summon 1 Aqua monster from GY
+	--If opponent Normal Summons, Special Summon 1 Aqua monster from GY
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_SUMMON_SUCCESS)
@@ -13,20 +14,17 @@ function s.initial_effect(c)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 end
-function s.filter1(c,tp)
+function s.filter(c,tp)
 	return c:IsSummonPlayer(1-tp) and c:IsLocation(LOCATION_MZONE) and c:IsLevelAbove(7)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(s.filter1,1,nil,tp) and Duel.IsExistingMatchingCard(s.costfilter,tp,LOCATION_MZONE,0,1,nil)
+	return eg:IsExists(s.filter,1,nil,tp) and Duel.IsExistingMatchingCard(s.costfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function s.costfilter(c)
 	return c:IsRace(RACE_WYRM) and c:IsFaceup() and c:IsAbleToGraveAsCost() and not c:IsMaximumModeSide()
 end
-function s.filter(c)
-	return c:IsFaceup() and c:CanAttack()
-end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,0,LOCATION_MZONE,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(aux.FaceupFilter(Card.CanAttack),tp,0,LOCATION_MZONE,1,nil) end
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	-- requirement
@@ -37,22 +35,19 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ct=Duel.SendtoGrave(g,REASON_COST)
 	if ct>0 then
 		--Effect
-		local g=Duel.SelectMatchingCard(tp,s.filter,tp,0,LOCATION_MZONE,1,1,nil)
+		local g=Duel.SelectMatchingCard(tp,aux.FaceupFilter(Card.CanAttack),tp,0,LOCATION_MZONE,1,1,nil)
 		Duel.HintSelection(g,true)
 		if #g>0 then
 			--cannot attack
-			local ge2=Effect.CreateEffect(e:GetHandler())
-			ge2:SetType(EFFECT_TYPE_FIELD)
-			ge2:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
-			ge2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
-			ge2:SetTargetRange(0,LOCATION_MZONE)
-			ge2:SetTarget(s.atktg)
-			ge2:SetLabel(g:GetFirst():GetRace())
-			ge2:SetReset(RESET_PHASE+PHASE_END)
-			Duel.RegisterEffect(ge2,tp)
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_FIELD)
+			e1:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+			e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+			e1:SetTargetRange(0,LOCATION_MZONE)
+			e1:SetTarget(function(e,c) return c:IsRace(e:GetLabel()) end)
+			e1:SetLabel(g:GetFirst():GetRace())
+			e1:SetReset(RESET_PHASE|PHASE_END)
+			Duel.RegisterEffect(e1,tp)
 		end
 	end
-end
-function s.atktg(e,c)
-	return c:IsRace(e:GetLabel())
 end

--- a/rush/c160012065.lua
+++ b/rush/c160012065.lua
@@ -47,8 +47,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		dg=dg:AddMaximumCheck()
 		if #dg>0 then
 			Duel.HintSelection(dg,true)
-			Duel.Destroy(dg,REASON_EFFECT)
-			if Duel.IsExistingMatchingCard(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
+			if Duel.Destroy(dg,REASON_EFFECT)>0 and Duel.IsExistingMatchingCard(Card.IsFaceup,tp,0,LOCATION_MZONE,1,nil) and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
 				local sg=Duel.SelectMatchingCard(tp,aux.FilterMaximumSideFunctionEx(Card.IsFaceup),tp,0,LOCATION_MZONE,1,1,nil)
 				if #sg>0 then

--- a/rush/c160206004.lua
+++ b/rush/c160206004.lua
@@ -23,7 +23,7 @@ function s.valcheck(e,c)
 	if #g==1 and g:GetFirst():GetFlagEffect(FLAG_DOUBLE_TRIB)>0 then
 		atk=g:GetFirst():GetTextAttack()*2
 	else
-		for tc g:Iter() do
+		for tc in g:Iter() do
 			local catk=tc:GetTextAttack()
 			atk=atk+(catk>=0 and catk or 0)
 		end

--- a/rush/c160206004.lua
+++ b/rush/c160206004.lua
@@ -20,9 +20,13 @@ function s.valcheck(e,c)
 	local g=c:GetMaterial()
 	local tc=g:GetFirst()
 	local atk=0
-	for tc in aux.Next(g) do
-		local catk=tc:GetTextAttack()
-		atk=atk+(catk>=0 and catk or 0)
+	if #g==1 and g:GetFirst():GetFlagEffect(FLAG_DOUBLE_TRIB)>0 then
+		atk=g:GetFirst():GetTextAttack()*2
+	else
+		for tc in aux.Next(g) do
+			local catk=tc:GetTextAttack()
+			atk=atk+(catk>=0 and catk or 0)
+		end
 	end
 	if e:GetLabel()==1 then
 		e:SetLabel(0)

--- a/rush/c160206004.lua
+++ b/rush/c160206004.lua
@@ -23,7 +23,7 @@ function s.valcheck(e,c)
 	if #g==1 and g:GetFirst():GetFlagEffect(FLAG_DOUBLE_TRIB)>0 then
 		atk=g:GetFirst():GetTextAttack()*2
 	else
-		for tc in aux.Next(g) do
+		for tc g:Iter() do
 			local catk=tc:GetTextAttack()
 			atk=atk+(catk>=0 and catk or 0)
 		end


### PR DESCRIPTION
- If Maju Garzett is Summoned by Tributing 1 Double Tributer, it should gain twice its ATK.
- Constructor Blockade should not be able to choose a monster that cannot attack.
- Phantom Roar should not be able to reduce ATK if it doesn't destroy a monster.
