### PR TITLE
fixed some rush cards according to new rulings

### DIFF
--- a/rush/c160011024.lua
+++ b/rush/c160011024.lua
@@ -42,7 +42,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
 	local dam=Duel.Damage(p,#g*200,REASON_EFFECT)
 	local g2=Duel.GetMatchingGroup(aux.FilterMaximumSideFunctionEx(Card.IsFaceup),tp,0,LOCATION_MZONE,nil)
-	if #g2>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
+	if dam>0 and #g2>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
 		for tc in g2:Iter() do
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)

--- a/rush/c160202041.lua
+++ b/rush/c160202041.lua
@@ -16,7 +16,7 @@ function s.initial_effect(c)
 end
 	--If your attack position DARK monster with 0 ATK was destroyed by opponent's attack
 function s.filter(c,tp)
-	return c:IsAttribute(ATTRIBUTE_DARK) and c:GetBaseAttack()==0 and c:IsPreviousPosition(POS_ATTACK)
+	return c:IsAttribute(ATTRIBUTE_DARK) and c:GetPreviousAttackOnField()==0 and c:IsPreviousPosition(POS_ATTACK)
 		and c:GetReasonPlayer()==1-tp and c:IsPreviousControler(tp) and c:IsPreviousLocation(LOCATION_MZONE)
 		and (c:IsReason(REASON_BATTLE) and Duel.GetAttacker():IsControler(1-tp))
 end

--- a/rush/c160207014.lua
+++ b/rush/c160207014.lua
@@ -51,6 +51,5 @@ function s.actcon(e)
 	return Duel.GetAttacker()==e:GetHandler()
 end
 function s.indcon(e)
-	--maximum mode check to do
-	return e:GetHandler():IsMaximumMode()
+	return e:GetHandler():IsMaximumMode() and not Duel.IsExistingMatchingCard(Card.IsMonster,tp,LOCATION_GRAVE,0,1,nil)
 end

--- a/rush/c160207014.lua
+++ b/rush/c160207014.lua
@@ -51,5 +51,5 @@ function s.actcon(e)
 	return Duel.GetAttacker()==e:GetHandler()
 end
 function s.indcon(e)
-	return e:GetHandler():IsMaximumMode() and not Duel.IsExistingMatchingCard(Card.IsMonster,tp,LOCATION_GRAVE,0,1,nil)
+	return e:GetHandler():IsMaximumMode() and not Duel.IsExistingMatchingCard(Card.IsMonster,e:GetHandlerPlayer(),LOCATION_GRAVE,0,1,nil)
 end

--- a/rush/c160207017.lua
+++ b/rush/c160207017.lua
@@ -25,7 +25,7 @@ function s.initial_effect(c)
 end
 s.MaximumAttack=4000
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsMaximumMode()
+	return e:GetHandler():IsMaximumMode() and not Duel.IsExistingMatchingCard(Card.IsMonster,e:GetHandlerPlayer(),LOCATION_GRAVE,0,1,nil)
 end
 function s.filter1(c)
 	return c:IsCode(160207016)


### PR DESCRIPTION
- Collapsing Chair should look at the previous attack on field to trigger
- Abyss Kraken and Abyss Poseidra need to have both their conditions fullfilled to apply their secondary effect
- Prophecy Phrase shouldn't ask about reducing ATK if it doesn't inflict damage
