### PR TITLE
Handle EFFECT_EXTRA_RELEASE in the ritual procedure

### DIFF
--- a/proc_ritual.lua
+++ b/proc_ritual.lua
@@ -161,6 +161,17 @@ function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselect
 					--add that forcedselection to the one of the Ritual Spell, if any
 					local extra_eff_g=mg:Filter(Card.IsHasEffect,nil,EFFECT_EXTRA_RITUAL_MATERIAL)
 					local func=forcedselection
+					--if a card controlled by the opponent has EFFECT_EXTRA_RELEASE, then it MUST be
+					--used as material
+					local extra_mat_g=mg:Filter(ExtraReleaseFilter,nil,tp)
+					if #extra_mat_g>0 then
+						--if one of those cards is facedown, then it can't be used as material, thus the
+						--summon is not doable
+						if extra_mat_g:IsExists(Card.IsPosition,1,nil,POS_FACEDOWN) then
+							return false
+						end
+						func=MergeForcedSelection(ForceExtraRelease(extra_mat_g),func)
+					end
 					if #extra_eff_g>0 then
 						local prev_repl_function=nil
 						for tmp_c in extra_eff_g:Iter() do
@@ -173,12 +184,6 @@ function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselect
 								end
 							end
 						end
-					end
-					--if a card controlled by the opponent has EFFECT_EXTRA_RELEASE, then it MUST be
-					--used as material
-					local extra_mat_g=mg:Filter(ExtraReleaseFilter,nil,tp)
-					if #extra_mat_g>0 then
-						func=MergeForcedSelection(ForceExtraRelease(extra_mat_g),func)
 					end
 					Ritual.CheckMatFilter(matfilter,e,tp,mg,mg2)
 					return Duel.IsExistingMatchingCard(Ritual.Filter,tp,location,0,1,e:GetHandler(),filter,_type,e,tp,mg,mg2,func,specificmatfilter,lv,requirementfunc,sumpos)

--- a/proc_ritual.lua
+++ b/proc_ritual.lua
@@ -5,32 +5,6 @@ end
 if not Ritual then
 	Ritual = aux.RitualProcedure
 end
---overwrite Duel.GetRitualMaterial to return Extra Deck monsters
---that have an EFFECT_EXTRA_RITUAL_MATERIAL effect on them
-Duel.GetRitualMaterial=(function()
-	local oldfunc=Duel.GetRitualMaterial
-	return function(tp,...)
-		local res=oldfunc(tp,...):Match(function(c)return c:IsControler(tp) or c:IsFaceup() end,nil)
-		local g=Duel.GetMatchingGroup(Card.IsHasEffect,tp,LOCATION_DECK|LOCATION_EXTRA,0,nil,EFFECT_EXTRA_RITUAL_MATERIAL)
-		if #g>0 then
-			res:Merge(g)
-		end
-		return res
-	end
-end)()
---overwrite Duel.ReleaseRitualMaterial to support sending Extra Deck
---"mats" to the GY by default
-Duel.ReleaseRitualMaterial=(function()
-	local oldfunc=Duel.ReleaseRitualMaterial
-	return function(g)
-		local extra_g=g:Filter(Card.IsLocation,nil,LOCATION_DECK|LOCATION_EXTRA)
-		if #extra_g>0 then
-			Duel.SendtoGrave(extra_g,REASON_RITUAL+REASON_EFFECT+REASON_MATERIAL)
-			g:Sub(extra_g)
-		end
-		return oldfunc(g)
-	end
-end)()
 function Ritual.GetMatchingFilterFunction(c)
 	local mt=c.__index
 	if not mt.ritual_matching_function or not mt.ritual_matching_function[c] then

--- a/proc_ritual.lua
+++ b/proc_ritual.lua
@@ -9,8 +9,8 @@ end
 --that have an EFFECT_EXTRA_RITUAL_MATERIAL effect on them
 Duel.GetRitualMaterial=(function()
 	local oldfunc=Duel.GetRitualMaterial
-	return function(tp,check)
-		local res=oldfunc(tp,check)
+	return function(tp,...)
+		local res=oldfunc(tp,...):Match(function(c)return c:IsControler(tp) or c:IsFaceup() end,nil)
 		local g=Duel.GetMatchingGroup(Card.IsHasEffect,tp,LOCATION_DECK|LOCATION_EXTRA,0,nil,EFFECT_EXTRA_RITUAL_MATERIAL)
 		if #g>0 then
 			res:Merge(g)
@@ -165,11 +165,6 @@ function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselect
 					--used as material
 					local extra_mat_g=mg:Filter(ExtraReleaseFilter,nil,tp)
 					if #extra_mat_g>0 then
-						--if one of those cards is facedown, then it can't be used as material, thus the
-						--summon is not doable
-						if extra_mat_g:IsExists(Card.IsPosition,1,nil,POS_FACEDOWN) then
-							return false
-						end
 						func=MergeForcedSelection(ForceExtraRelease(extra_mat_g),func)
 					end
 					if #extra_eff_g>0 then

--- a/proc_ritual.lua
+++ b/proc_ritual.lua
@@ -104,8 +104,20 @@ function(c,_type,filter,lv,desc,extrafil,extraop,matfilter,stage2,location,force
 end,"handler","lvtype","filter","lv","desc","extrafil","extraop","matfilter","stage2","location","forcedselection","customoperation","specificmatfilter","requirementfunc","sumpos","extratg")
 
 local function WrapTableReturn(func)
+	if func then
+		return function(...)
+			return {func(...)}
+		end
+	end
+end
+local function MergeForcedSelection(f1,f2)
+	if f1==nil or f2==nil then
+		return f1 or f2
+	end
 	return function(...)
-		return {func(...)}
+		local ret1,ret2=f1(...)
+		local repl1,repl2=f2(...)
+		return ret1 and repl1,ret2 or repl2
 	end
 end
 function Ritual.Filter(c,filter,_type,e,tp,m,m2,forcedselection,specificmatfilter,lv,requirementfunc,sumpos)
@@ -124,19 +136,19 @@ function Ritual.Filter(c,filter,_type,e,tp,m,m2,forcedselection,specificmatfilte
 	if specificmatfilter then
 		mg:Match(specificmatfilter,nil,c,mg,tp)
 	end
-	local func=forcedselection and WrapTableReturn(forcedselection) or nil
-	if c.ritual_custom_check then
-		if forcedselection then
-			func=aux.tableAND(WrapTableReturn(c.ritual_custom_check),forcedselection)
-		else
-			func=WrapTableReturn(c.ritual_custom_check)
-		end
-	end
-	local res=aux.SelectUnselectGroup(mg,e,tp,1,lv,Ritual.Check(c,lv,func,_type,requirementfunc),0)
+	forcedselection=MergeForcedSelection(c.ritual_custom_check,forcedselection)
+	local res=aux.SelectUnselectGroup(mg,e,tp,1,lv,Ritual.Check(c,lv,WrapTableReturn(forcedselection),_type,requirementfunc),0)
 	Ritual.SummoningLevel=nil
 	return res
 end
-
+local function ExtraReleaseFilter(c,tp)
+	return c:IsControler(1-tp) and c:IsHasEffect(EFFECT_EXTRA_RELEASE)
+end
+local function ForceExtraRelease(mg)
+	return function(e,tp,g,c)
+		return g:Includes(mg)
+	end
+end
 Ritual.Target = aux.FunctionWithNamedArgs(
 function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselection,specificmatfilter,requirementfunc,sumpos,extratg)
 	location = location or LOCATION_HAND
@@ -148,6 +160,7 @@ function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselect
 					--if an EFFECT_EXTRA_RITUAL_MATERIAL effect has a forcedselection of its own
 					--add that forcedselection to the one of the Ritual Spell, if any
 					local extra_eff_g=mg:Filter(Card.IsHasEffect,nil,EFFECT_EXTRA_RITUAL_MATERIAL)
+					local func=forcedselection
 					if #extra_eff_g>0 then
 						local prev_repl_function=nil
 						for tmp_c in extra_eff_g:Iter() do
@@ -156,24 +169,19 @@ function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselect
 								local repl_function=eff:GetLabelObject()
 								if repl_function and prev_repl_function~=repl_function[1] then
 									prev_repl_function=repl_function[1]
-									if not forcedselection then
-										forcedselection=repl_function[1]
-									elseif forcedselection~=repl_function[1] then
-										forcedselection=(function()
-															local oldfunc=forcedselection
-															return function(e,tp,sg,sc)
-																local ret1,ret2=oldfunc(e,tp,sg,sc)
-																local repl1,repl2=repl_function[1](e,tp,sg,sc)
-																return ret1 and repl1,ret2 or repl2
-															end
-														end)()
-									end
+									func=MergeForcedSelection(func,repl_function[1])
 								end
 							end
 						end
 					end
+					--if a card controlled by the opponent has EFFECT_EXTRA_RELEASE, then it MUST be
+					--used as material
+					local extra_mat_g=mg:Filter(ExtraReleaseFilter,nil,tp)
+					if #extra_mat_g>0 then
+						func=MergeForcedSelection(ForceExtraRelease(extra_mat_g),func)
+					end
 					Ritual.CheckMatFilter(matfilter,e,tp,mg,mg2)
-					return Duel.IsExistingMatchingCard(Ritual.Filter,tp,location,0,1,e:GetHandler(),filter,_type,e,tp,mg,mg2,forcedselection,specificmatfilter,lv,requirementfunc,sumpos)
+					return Duel.IsExistingMatchingCard(Ritual.Filter,tp,location,0,1,e:GetHandler(),filter,_type,e,tp,mg,mg2,func,specificmatfilter,lv,requirementfunc,sumpos)
 				end
 				if extratg then extratg(e,tp,eg,ep,ev,re,r,rp,chk) end
 				Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,location)
@@ -239,6 +247,7 @@ function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselect
 				local mg2=extrafil and extrafil(e,tp,eg,ep,ev,re,r,rp) or Group.CreateGroup()
 				--if an EFFECT_EXTRA_RITUAL_MATERIAL effect has a forcedselection of its own
 				--add that forcedselection to the one of the Ritual Spell, if any
+				local func=forcedselection
 				local extra_eff_g=mg:Filter(Card.IsHasEffect,nil,EFFECT_EXTRA_RITUAL_MATERIAL)
 				if #extra_eff_g>0 then
 					local prev_repl_function=nil
@@ -248,26 +257,21 @@ function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselect
 							local repl_function=eff:GetLabelObject()
 							if repl_function and prev_repl_function~=repl_function[1] then
 								prev_repl_function=repl_function[1]
-								if not forcedselection then
-									forcedselection=repl_function[1]
-								elseif forcedselection~=repl_function[1] then
-									forcedselection=(function()
-														local oldfunc=forcedselection
-														return function(e,tp,sg,sc)
-															local ret1,ret2=oldfunc(e,tp,sg,sc)
-															local repl1,repl2=repl_function[1](e,tp,sg,sc)
-															return ret1 and repl1,ret2 or repl2
-														end
-													end)()
-								end
+								func=MergeForcedSelection(func,repl_function[1])
 							end
 						end
 					end
 				end
+				--if a card controlled by the opponent has EFFECT_EXTRA_RELEASE, then it MUST be
+				--used as material
+				local extra_mat_g=mg:Filter(ExtraReleaseFilter,nil,tp)
+				if #extra_mat_g>0 then
+					func=MergeForcedSelection(ForceExtraRelease(extra_mat_g),func)
+				end
 				Ritual.CheckMatFilter(matfilter,e,tp,mg,mg2)
 				local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-				local tg=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(Ritual.Filter),tp,location,0,1,1,e:GetHandler(),filter,_type,e,tp,mg,mg2,forcedselection,specificmatfilter,lv,requirementfunc,sumpos)
+				local tg=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(Ritual.Filter),tp,location,0,1,1,e:GetHandler(),filter,_type,e,tp,mg,mg2,func,specificmatfilter,lv,requirementfunc,sumpos)
 				if #tg>0 then
 					local tc=tg:GetFirst()
 					local lv=(lv and (type(lv)=="function" and lv(tc)) or lv) or tc:GetLevel()
@@ -280,17 +284,10 @@ function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselect
 						mg:Match(specificmatfilter,nil,tc,mg,tp)
 					end
 					if tc.ritual_custom_operation then
-						tc:ritual_custom_operation(mg,forcedselection,_type)
+						tc:ritual_custom_operation(mg,func,_type)
 						mat=tc:GetMaterial()
 					else
-						local func=forcedselection and WrapTableReturn(forcedselection) or nil
-						if tc.ritual_custom_check then
-							if forcedselection then
-								func=aux.tableAND(WrapTableReturn(tc.ritual_custom_check),forcedselection)
-							else
-								func=WrapTableReturn(tc.ritual_custom_check)
-							end
-						end
+						func=MergeForcedSelection(tc.ritual_custom_check,func)
 						if tc.mat_filter then
 							mg:Match(tc.mat_filter,tc,tp)
 						end
@@ -302,7 +299,7 @@ function(filter,_type,lv,extrafil,extraop,matfilter,stage2,location,forcedselect
 								mat=mg:SelectWithSumGreater(tp,requirementfunc or Card.GetRitualLevel,lv,tc)
 							end
 						else
-							mat=aux.SelectUnselectGroup(mg,e,tp,1,lv,Ritual.Check(tc,lv,func,_type,requirementfunc),1,tp,HINTMSG_RELEASE,Ritual.Finishcon(tc,lv,requirementfunc,_type))
+							mat=aux.SelectUnselectGroup(mg,e,tp,1,lv,Ritual.Check(tc,lv,WrapTableReturn(func),_type,requirementfunc),1,tp,HINTMSG_RELEASE,Ritual.Finishcon(tc,lv,requirementfunc,_type))
 						end
 					end
 					--check if a card from an "once per turn" EFFECT_EXTRA_RITUAL_MATERIAL effect was selected


### PR DESCRIPTION
If a monster was targeted by Soul Exchange, then that monster has to be tributed as material for a Ritual Summon, handle such scenario.
~~Remaining to investigate is what to do with facedown monsters that were targeted by exchange, if to prevent the player from ritual summoning at all, or exclude those facedown cards as they can't be used as materials since they don't have their stats public.~~ ~~Make so that if one of those cards is facedown, the summon cannot be performed.~~ Facedown monsters have to be ignored.
Also some minor bugs present in the procedure have been fixed.