### PR TITLE
Unofficial Fixes

### DIFF
--- a/unofficial/c511000412.lua
+++ b/unofficial/c511000412.lua
@@ -2,37 +2,24 @@
 --Fearful Earthbound
 local s,id=GetID()
 function s.initial_effect(c)
-	--activate
+	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
-	e1:SetTarget(s.target)
+	e1:SetCondition(s.damcon)
 	c:RegisterEffect(e1)
-	--
+	--Inflict 500 damage
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_DAMAGE)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetCode(EVENT_DAMAGE_STEP_END)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCondition(s.damcon)
 	e2:SetTarget(s.damtg)
 	e2:SetOperation(s.damop)
 	c:RegisterEffect(e2)
-end
-function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	if s.damcon(e,tp,eg,ep,ev,re,r,rp) and s.damtg(e,tp,eg,ep,ev,re,r,rp,0) then
-		e:SetCategory(CATEGORY_DAMAGE)
-		e:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-		e:SetOperation(s.damop)
-		s.damtg(e,tp,eg,ep,ev,re,r,rp,1)
-	else
-		e:SetCategory(0)
-		e:SetProperty(0)
-		e:SetOperation(nil)
-	end
 end
 function s.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetAttacker():IsControler(1-tp)
@@ -44,7 +31,6 @@ function s.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,500)
 end
 function s.damop(e,tp,eg,ep,ev,re,r,rp)
-	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
 	Duel.Damage(p,d,REASON_EFFECT)
 end

--- a/unofficial/c511000657.lua
+++ b/unofficial/c511000657.lua
@@ -4,6 +4,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--Special Summon 1 Dinosaur monster from your hand
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
@@ -26,7 +27,7 @@ function s.rescon(sg,e,tp,mg)
 	return aux.ChkfMMZ(1)(sg,e,tp,mg) and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp,#sg)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	local cg=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,nil)
+	local cg=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_MZONE|LOCATION_GRAVE,0,nil)
 	if chk==0 then
 		if e:GetLabel()~=1 then return false end
 		e:SetLabel(0)
@@ -46,7 +47,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CANNOT_ATTACK)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e1:SetReset(RESET_EVENT|RESETS_STANDARD|RESET_PHASE|PHASE_END)
 		tc:RegisterEffect(e1,true)
 		Duel.SpecialSummonComplete()
 	end

--- a/unofficial/c511000657.lua
+++ b/unofficial/c511000657.lua
@@ -1,8 +1,8 @@
---時空超越
---Spacetime Transcendence
+--時空超越 (Anime)
+--Spacetime Transcendence (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Special Summon 1 Dinosaur monster from your hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -16,7 +16,7 @@ function s.cfilter(c)
 	return c:IsRace(RACE_DINOSAUR) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c,true)
 end
 function s.spfilter(c,e,tp,lv)
-	return c:IsCanBeSpecialSummoned(e,0,tp,false,false) and c:GetLevel()==lv
+	return c:IsRace(RACE_DINOSAUR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false) and c:GetLevel()==lv
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)

--- a/unofficial/c511002520.lua
+++ b/unofficial/c511002520.lua
@@ -4,6 +4,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--Negate that effect and destroy that card, then Special Summon "Stardust Dragon"
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_DISABLE+CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_CHAINING)

--- a/unofficial/c511002520.lua
+++ b/unofficial/c511002520.lua
@@ -1,8 +1,8 @@
---スターライト・ロード (Manga)
---Starlight Road (Manga)
+--スターライト・ロード (Anime)
+--Starlight Road (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Negate that effect and destroy that card, then Special Summon "Stardust Dragon"
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_DISABLE+CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -17,7 +17,7 @@ function s.cfilter(c,p)
 	return c:GetControler()==p and c:IsOnField()
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsChainDisablable(ev) then return false end
+	if tp==ep or not Duel.IsChainDisablable(ev) then return false end
 	local ex,tg,tc=Duel.GetOperationInfo(ev,CATEGORY_DESTROY)
 	return ex and tg~=nil and tc+tg:FilterCount(s.cfilter,nil,tp)-#tg>1
 end

--- a/unofficial/c511002541.lua
+++ b/unofficial/c511002541.lua
@@ -1,41 +1,58 @@
---ヘル・ブラスト
+--ヘル・ブラスト (Anime)
+--Chthonian Blast (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Destroy 1 monster on the field, and if you do, inflict damage to your opponent equal to half its ATK
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetCode(EVENT_TO_GRAVE)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCondition(s.condition)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
+	aux.GlobalCheck(s,function()
+		s[0]=false
+		s[1]=false
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetCode(EVENT_DESTROYED)
+		ge1:SetOperation(s.checkop1)
+		Duel.RegisterEffect(ge1,0)
+		aux.AddValuesReset(function()
+			s[0]=false
+			s[1]=false
+		end)
+	end)
 end
-function s.cfilter(c,tp)
-	return c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
-		and c:IsPreviousControler(tp) and c:IsReason(REASON_DESTROY)
+function s.checkop1(e,tp,eg,ep,ev,re,r,rp)
+	for tc in aux.Next(eg) do
+		if tc:IsPreviousLocation(LOCATION_MZONE) then
+			s[tc:GetPreviousControler()]=true
+		end
+	end
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(s.cfilter,1,nil,tp)
+	return s[tp]
 end
-function s.filter(c)
-	return c:IsFaceup() and c:IsDestructable()
-end
-function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
-	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
+	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	local d=g:GetFirst()
+	local atk=0
+	if d:IsFaceup() then atk=d:GetAttack()/2 end
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,atk)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
-	local tc=g:GetFirst()
-	if tc then
-		Duel.HintSelection(g)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		local atk=0
+		if tc:IsFaceup() then atk=tc:GetAttack()/2 end
 		if Duel.Destroy(tc,REASON_EFFECT)>0 then
-			local atk=tc:GetAttack()/2
 			Duel.Damage(1-tp,atk,REASON_EFFECT)
 		end
 	end

--- a/unofficial/c511002541.lua
+++ b/unofficial/c511002541.lua
@@ -4,6 +4,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--Destroy 1 monster on the field, and if you do, inflict damage to your opponent equal to half its ATK
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)

--- a/unofficial/c511002541.lua
+++ b/unofficial/c511002541.lua
@@ -2,14 +2,13 @@
 --Chthonian Blast (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
-	--Destroy 1 monster on the field, and if you do, inflict damage to your opponent equal to half its ATK
+	--Destroy 1 face-up monster on the field, and if you do, inflict damage to your opponent equal to half its ATK
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCondition(s.condition)
+	e1:SetCondition(function(_,tp) return s[tp] end)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
@@ -34,27 +33,18 @@ function s.checkop1(e,tp,eg,ep,ev,re,r,rp)
 		end
 	end
 end
-function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return s[tp]
-end
-function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
-	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
-	local d=g:GetFirst()
-	local atk=0
-	if d:IsFaceup() then atk=d:GetAttack()/2 end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,atk)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
-		local atk=0
-		if tc:IsFaceup() then atk=tc:GetAttack()/2 end
-		if Duel.Destroy(tc,REASON_EFFECT)>0 then
-			Duel.Damage(1-tp,atk,REASON_EFFECT)
-		end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local tc=Duel.SelectMatchingCard(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil):GetFirst()
+	if not tc then return end
+	local dam=tc:GetAttack()/2
+	if Duel.Destroy(tc,REASON_EFFECT)>0 then
+		Duel.Damage(1-tp,dam,REASON_EFFECT)
 	end
 end

--- a/unofficial/c511002874.lua
+++ b/unofficial/c511002874.lua
@@ -1,4 +1,5 @@
---ジュラシックワールド
+--ジュラシックワールド (Anime)
+--Jurassic World (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -6,41 +7,49 @@ function s.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	c:RegisterEffect(e1)
-	--Atk
+	--Dinosaur and Winged Beast monsters gain 300 ATK and DEF
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
 	e2:SetCode(EFFECT_UPDATE_ATTACK)
 	e2:SetRange(LOCATION_FZONE)
 	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
-	e2:SetTarget(aux.TargetBoolFunction(Card.IsRace,RACE_DINOSAUR+RACE_WINGEDBEAST))
+	e2:SetTarget(aux.TargetBoolFunction(Card.IsRace,RACE_DINOSAUR|RACE_WINGEDBEAST))
 	e2:SetValue(300)
 	c:RegisterEffect(e2)
-	--Def
 	local e3=e2:Clone()
 	e3:SetCode(EFFECT_UPDATE_DEFENSE)
 	c:RegisterEffect(e3)
-	--immune
+	--Your opponent cannot target Dinosaur or Winged Beast monsters with Trap effects
 	local e4=e2:Clone()
-	e4:SetCode(EFFECT_IMMUNE_EFFECT)
-	e4:SetValue(s.efilter)
+	e4:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e4:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+	e4:SetValue(s.efilter1)
 	c:RegisterEffect(e4)
-	--change battle target
-	local e5=Effect.CreateEffect(c)
-	e5:SetDescription(aux.Stringid(42256406,1))
-	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
-	e5:SetCode(EVENT_BE_BATTLE_TARGET)
-	e5:SetRange(LOCATION_FZONE)
-	e5:SetCondition(s.cbcon)
-	e5:SetOperation(s.cbop)
+	--Dinosaur and Winged Beast monsters are unaffected by your opponent's Trap effects
+	local e5=e2:Clone()
+	e5:SetCode(EFFECT_IMMUNE_EFFECT)
+	e5:SetValue(s.efilter2)
 	c:RegisterEffect(e5)
+	--Change that monster to Defense Position
+	local e6=Effect.CreateEffect(c)
+	e6:SetDescription(aux.Stringid(id,0))
+	e6:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e6:SetCode(EVENT_BE_BATTLE_TARGET)
+	e6:SetRange(LOCATION_FZONE)
+	e6:SetCondition(s.cbcon)
+	e6:SetOperation(s.cbop)
+	c:RegisterEffect(e6)
 end
-function s.efilter(e,te)
-	return te:IsActiveType(TYPE_TRAP) and e:GetOwnerPlayer()~=te:GetOwnerPlayer()
+function s.efilter1(e,re,rp)
+	return re:IsActiveType(TYPE_TRAP) and e:GetHandlerPlayer()~=rp
+end
+function s.efilter2(e,te)
+	return te:IsActiveType(TYPE_TRAP) and e:GetHandlerPlayer()~=te:GetOwnerPlayer()
 end
 function s.cbcon(e,tp,eg,ep,ev,re,r,rp)
 	local bt=eg:GetFirst()
-	return r~=REASON_REPLACE and bt:IsFaceup() and bt:IsControler(tp) and bt:IsRace(RACE_DINOSAUR+RACE_WINGEDBEAST) 
-		and bt:IsAttackPos()
+	return r~=REASON_REPLACE and bt:IsFaceup() and bt:IsControler(tp) and bt:IsRace(RACE_DINOSAUR|RACE_WINGEDBEAST) 
+		and bt:IsAttackPos() and Duel.GetAttacker():IsControler(1-tp)
 end
 function s.cbop(e,tp,eg,ep,ev,re,r,rp)
 	local at=eg:GetFirst()

--- a/unofficial/c511002874.lua
+++ b/unofficial/c511002874.lua
@@ -41,10 +41,10 @@ function s.initial_effect(c)
 	c:RegisterEffect(e6)
 end
 function s.efilter1(e,re,rp)
-	return re:IsActiveType(TYPE_TRAP) and e:GetHandlerPlayer()~=rp
+	return re:IsTrapEffect() and e:GetHandlerPlayer()~=rp
 end
 function s.efilter2(e,te)
-	return te:IsActiveType(TYPE_TRAP) and e:GetHandlerPlayer()~=te:GetOwnerPlayer()
+	return te:IsTrapEffect() and e:GetHandlerPlayer()~=te:GetOwnerPlayer()
 end
 function s.cbcon(e,tp,eg,ep,ev,re,r,rp)
 	local bt=eg:GetFirst()

--- a/unofficial/c511013016.lua
+++ b/unofficial/c511013016.lua
@@ -1,35 +1,33 @@
---Release Restraint Wave
+--拘束解放波 (Anime)
+--Release Restraint Wave (Anime)
 --cleaned up by MLD
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Destroy all Spells and Traps your opponent controls
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(s.cost)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 end
 function s.filter(c)
-	return c:IsFaceup() and c:IsType(TYPE_EQUIP)
+	return c:IsFaceup() and c:IsEquipSpell() and c:IsDestructable()
 end
-function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_SZONE) and chkc:IsControler(tp) and s.filter(chkc) end
-	if chk==0 then return Duel.IsExistingTarget(s.filter,tp,LOCATION_SZONE,0,1,nil)
-		and Duel.IsExistingMatchingCard(Card.IsType,tp,0,LOCATION_ONFIELD,1,nil,TYPE_SPELL+TYPE_TRAP) end
+function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_ONFIELD,0,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_SZONE,0,1,1,nil)
-	local dg=Duel.GetMatchingGroup(Card.IsType,tp,0,LOCATION_ONFIELD,nil,TYPE_SPELL+TYPE_TRAP)
-	dg:Merge(g)
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_ONFIELD,0,1,1,nil)
+	Duel.Destroy(g,REASON_COST)
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local dg=Duel.GetMatchingGroup(Card.IsSpellTrap,tp,0,LOCATION_ONFIELD,nil)
+	if chk==0 then return #dg>0 end
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,dg,#dg,0,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
-		local dg=Duel.GetMatchingGroup(Card.IsType,tp,0,LOCATION_ONFIELD,nil,TYPE_SPELL+TYPE_TRAP)
-		dg:AddCard(tc)
-		Duel.Destroy(dg,REASON_EFFECT)
-	end
+	local dg=Duel.GetMatchingGroup(Card.IsSpellTrap,tp,0,LOCATION_ONFIELD,nil)
+	if #dg>0 then Duel.Destroy(dg,REASON_EFFECT) end
 end

--- a/unofficial/c511013016.lua
+++ b/unofficial/c511013016.lua
@@ -5,6 +5,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--Destroy all Spells and Traps your opponent controls
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
@@ -23,11 +24,11 @@ function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Destroy(g,REASON_COST)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	local dg=Duel.GetMatchingGroup(Card.IsSpellTrap,tp,0,LOCATION_ONFIELD,nil)
+	local dg=Duel.GetMatchingGroup(Card.IsSpellTrap,tp,0,LOCATION_ONFIELD,e:GetHandler())
 	if chk==0 then return #dg>0 end
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,dg,#dg,0,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local dg=Duel.GetMatchingGroup(Card.IsSpellTrap,tp,0,LOCATION_ONFIELD,nil)
-	if #dg>0 then Duel.Destroy(dg,REASON_EFFECT) end
+	local sg=Duel.GetMatchingGroup(Card.IsSpellTrap,tp,0,LOCATION_ONFIELD,e:GetHandler())
+	Duel.Destroy(sg,REASON_EFFECT)
 end

--- a/unofficial/c511021000.lua
+++ b/unofficial/c511021000.lua
@@ -1,10 +1,9 @@
 --フォーチュンレディ・ライティー (Anime)
 --Fortune Lady Light (Anime)
 --fixed by MLD & Larry126
-local s,id,alias=GetID()
+local s,id=GetID()
 function s.initial_effect(c)
-	alias=c:GetOriginalCodeRule()
-	--atk,def
+	--This card's ATK/DEF become its Level x 200
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
@@ -15,9 +14,9 @@ function s.initial_effect(c)
 	local e2=e1:Clone()
 	e2:SetCode(EFFECT_SET_DEFENSE)
 	c:RegisterEffect(e2)
-	--level up
+	--Increase this card's Level by 1 (max. 12)
 	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(alias,0))
+	e3:SetDescription(aux.Stringid(id,0))
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetCountLimit(1)
@@ -25,19 +24,18 @@ function s.initial_effect(c)
 	e3:SetCondition(s.lvcon)
 	e3:SetOperation(s.lvop)
 	c:RegisterEffect(e3)
-	--special summon
+	--Special Summon 1 "Fortune Lady" monster from your Deck
 	local e4=Effect.CreateEffect(c)
-	e4:SetDescription(aux.Stringid(alias,1))
+	e4:SetDescription(aux.Stringid(id,1))
 	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e4:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
 	e4:SetCode(EVENT_LEAVE_FIELD)
 	e4:SetCondition(s.spcon)
 	e4:SetTarget(s.sptg)
 	e4:SetOperation(s.spop)
 	c:RegisterEffect(e4)
 end
-s.listed_series={0x31}
+s.listed_series={SET_FORTUNE_LADY}
 function s.value(e,c)
 	return c:GetLevel()*200
 end
@@ -56,13 +54,15 @@ function s.lvop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return not c:IsLocation(LOCATION_DECK)
+	return c:IsPreviousControler(tp) and not c:IsLocation(LOCATION_DECK) 
+		and c:IsPreviousPosition(POS_FACEUP)
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(0x31) and c:IsCanBeSpecialSummoned(e,0x8,tp,false,false)
+	return c:IsSetCard(SET_FORTUNE_LADY) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -70,6 +70,6 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	if #g>0 then
-		Duel.SpecialSummon(g,0x8,tp,tp,false,false,POS_FACEUP)
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/unofficial/c511021000.lua
+++ b/unofficial/c511021000.lua
@@ -49,7 +49,7 @@ function s.lvop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_UPDATE_LEVEL)
 	e1:SetValue(1)
-	e1:SetReset(RESET_EVENT+RESETS_STANDARD_DISABLE)
+	e1:SetReset(RESET_EVENT|RESETS_STANDARD_DISABLE)
 	c:RegisterEffect(e1)
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
@@ -58,7 +58,7 @@ function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 		and c:IsPreviousPosition(POS_FACEUP)
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(SET_FORTUNE_LADY) and c:IsCanBeSpecialSummoned(e,0x8,tp,false,false)
+	return c:IsSetCard(SET_FORTUNE_LADY) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -70,6 +70,6 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	if #g>0 then
-		Duel.SpecialSummon(g,0x8,tp,tp,false,false,POS_FACEUP)
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/unofficial/c511021000.lua
+++ b/unofficial/c511021000.lua
@@ -58,7 +58,7 @@ function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 		and c:IsPreviousPosition(POS_FACEUP)
 end
 function s.spfilter(c,e,tp)
-	return c:IsSetCard(SET_FORTUNE_LADY) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsSetCard(SET_FORTUNE_LADY) and c:IsCanBeSpecialSummoned(e,0x8,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -70,6 +70,6 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
 	if #g>0 then
-		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+		Duel.SpecialSummon(g,0x8,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/unofficial/c511600432.lua
+++ b/unofficial/c511600432.lua
@@ -32,16 +32,13 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	local ct=Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)
-	if ft>ct then ft=ct end
 	if ft<=0 then return end
 	if Duel.IsPlayerAffectedByEffect(tp,CARD_BLUEEYES_SPIRIT) then ft=1 end
+	if ft<ct then return end
 	if not Duel.IsPlayerCanSpecialSummonMonster(tp,27450401,0,TYPES_TOKEN,0,0,1,RACE_MACHINE,ATTRIBUTE_EARTH) then return end
-	local ctn=true
-	while ft>0 and ctn do
+	for i=1,ct do
 		local token=Duel.CreateToken(tp,27450401)
 		Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP)
-		ft=ft-1
-		if ft<=0 or not Duel.SelectYesNo(tp,aux.Stringid(id,2)) then ctn=false end
 	end
 	Duel.SpecialSummonComplete()
 end

--- a/unofficial/c513000076.lua
+++ b/unofficial/c513000076.lua
@@ -1,26 +1,26 @@
---Ｓｉｎ トゥルース・ドラゴン
+--Ｓｉｎ トゥルース・ドラゴン (Anime)
+--Malefic Truth Dragon (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
-	--Cannot special summon
+	--Must be Special Summoned with "Malefic Paradigm Shift"
 	local e1=Effect.CreateEffect(c)
 	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
-	e1:SetValue(aux.FALSE)
 	c:RegisterEffect(e1)
-	--special summon
+	--Destroy all monsters your opponent controls, then inflict 800 damage for each
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(55586621,1))
-	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetDescription(aux.Stringid(id,0))
+	e2:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetRange(LOCATION_MZONE)
-	e2:SetCode(EVENT_BATTLE_DESTROYING)
+	e2:SetCode(EVENT_BATTLE_DESTROYED)
 	e2:SetCondition(s.descon)
 	e2:SetTarget(s.destg)
 	e2:SetOperation(s.desop)
 	c:RegisterEffect(e2)
-	--self destroy
+	--If "Malefic World" is not on the field, destroy this card
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
@@ -28,7 +28,7 @@ function s.initial_effect(c)
 	e3:SetCode(EFFECT_SELF_DESTROY)
 	e3:SetCondition(s.descon2)
 	c:RegisterEffect(e3)
-	--Destroy replace
+	--If this card would be destroyed, you can banish 1 "Malefic" monster from your Graveyard instead
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
 	e4:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
@@ -37,21 +37,20 @@ function s.initial_effect(c)
 	e4:SetTarget(s.desreptg)
 	c:RegisterEffect(e4)
 end
-s.listed_names={27564031}
+s.listed_names={100000092,27564031}
+s.listed_series={SET_MALEFIC}
 function s.descon(e,tp,eg,ep,ev,re,r,rp)
-	local tc=eg:GetFirst()
-	local bc=tc:GetBattleTarget()
-	return tc:IsRelateToBattle() and tc:IsStatus(STATUS_OPPO_BATTLE) and tc:IsControler(tp) and tc:IsSetCard(0x23)
-		and bc:IsReason(REASON_BATTLE)
+	local rc,bc=Duel.GetBattleMonster(tp)
+	return rc and bc and rc:IsSetCard(SET_MALEFIC) and rc:IsControler(tp) and bc:IsPreviousControler(1-tp)
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chk==0 then return true end
-	local g=Duel.GetMatchingGroup(Card.IsDestructable,tp,0,LOCATION_MZONE,nil)
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_MZONE)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,#g*800)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(Card.IsDestructable,tp,0,LOCATION_MZONE,nil)
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_MZONE)
 	local ct=Duel.Destroy(g,REASON_EFFECT)
 	if ct~=0 then
 		Duel.BreakEffect()
@@ -62,15 +61,15 @@ function s.descon2(e)
 	return not Duel.IsEnvironment(27564031)
 end
 function s.repfilter(c)
-	return c:IsMonster() and c:IsSetCard(0x23) and c:IsAbleToRemoveAsCost()
+	return c:IsMonster() and c:IsSetCard(SET_MALEFIC) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c,true)
 end
 function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsReason(REASON_REPLACE) 
-		and Duel.IsExistingMatchingCard(s.repfilter,tp,LOCATION_GRAVE,0,1,nil) end
-	if Duel.SelectYesNo(tp,aux.Stringid(25165047,1)) then
+		and Duel.IsExistingMatchingCard(s.repfilter,tp,LOCATION_MZONE|LOCATION_GRAVE,0,1,nil) end
+	if Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-		local g=Duel.SelectMatchingCard(tp,s.repfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+		local g=Duel.SelectMatchingCard(tp,s.repfilter,tp,LOCATION_MZONE|LOCATION_GRAVE,0,1,1,nil)
 		Duel.Remove(g,POS_FACEUP,REASON_COST)
 		return true
 	else return false end

--- a/unofficial/c513000076.lua
+++ b/unofficial/c513000076.lua
@@ -67,7 +67,7 @@ function s.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	if chk==0 then return not c:IsReason(REASON_REPLACE) 
 		and Duel.IsExistingMatchingCard(s.repfilter,tp,LOCATION_MZONE|LOCATION_GRAVE,0,1,nil) end
-	if Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
+	if Duel.SelectEffectYesNo(tp,c,96) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 		local g=Duel.SelectMatchingCard(tp,s.repfilter,tp,LOCATION_MZONE|LOCATION_GRAVE,0,1,1,nil)
 		Duel.Remove(g,POS_FACEUP,REASON_COST)

--- a/unofficial/c810000050.lua
+++ b/unofficial/c810000050.lua
@@ -1,9 +1,11 @@
--- Card Breaker (Anime)
--- scripted by: UnknownGuest
+--カード・ブレイカー (Anime)
+--Card Breaker (Anime)
+--scripted by: UnknownGuest
 --fixed by MLD
 local s,id=GetID()
 function s.initial_effect(c)
-	-- spsummon proc
+	c:EnableReviveLimit()
+	--Special Summon procedure
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_SPSUMMON_PROC)


### PR DESCRIPTION
1. https://yugipedia.com/wiki/Fearful_Earthbound_(manga) - Changed the condition to be at the end of the damage step to more properly respect the wording/presentation of the card in the anime/manga

2. https://yugipedia.com/wiki/Spacetime_Transcendence_(anime) - According to the dialogue (full text not visible), should only be able to summon Dinosaur monsters

3. https://yugipedia.com/wiki/Starlight_Road_(anime) - Should not be usable on your own cards

4. https://web.archive.org/web/20221025001250/https://yugipedia.com/wiki/Chthonian_Blast_(anime) - Corrected the effect based on the available text/dialogue. I also changed it to target since that seems appropriate given the nature of the effect

5. https://yugipedia.com/wiki/Jurassic_World_(anime) - Should also prevent your opponent from targeting them with Trap effects and added a check to make sure the opponent's monster targeted them for an attack per the wording on the card. I wasn't 100% sure if this text from this era is meant to be read literally, meaning they cannot target them in any location (like Aurkus). If so I can correct it.

6. https://yugipedia.com/wiki/Release_Restraint_Wave_(anime) - fixed a bug where equips other than spells could be used and made destroying the equip spell a cost as that's how the original wording is phrased

7. https://yugipedia.com/wiki/Fortune_Lady_Light_(anime) - Its last effect was scripted to function like an "if" but should function like a "when". Updated to require leaving the field from your field per the original wording and added a face-up check due to similar wording with the OCG card. Lastly, added a missing activation legality check.

8. https://yugipedia.com/wiki/Cosmic_Compass_(anime) - The number of tokens must be equal to the number of monsters the opponent controls

9. https://yugipedia.com/wiki/Malefic_Truth_Dragon_(anime) - Fixed bugs where the effect to destroy+burn had the wrong SetCategory, was scripted to be optional despite being mandatory, would not trigger in cases where your other Malefic monster crashed with the opponent's monster, and was missing the Spirit Elimination handling for its protection effect. It is also scripted to be a "then", which based on something like Chaos Emperor Dragon's initial OCG wording I think is correct, but in game is worded as an "and".

10. https://yugipedia.com/wiki/Card_Breaker_(anime) Should function as a Semi-Nomi


- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
