### PR TITLE
Fix "Go-D/D World"

### DIFF
--- a/unofficial/c511027680.lua
+++ b/unofficial/c511027680.lua
@@ -1,5 +1,5 @@
---ＧＯ－ＤＤ・Ｗ０ＲＬＤ
 --Go-D/D World
+--ゴー－ディーディー・ワールド
 --Made by Beetron-1 Beetletop
 local s,id=GetID()
 function s.initial_effect(c)
@@ -7,29 +7,37 @@ function s.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(s.condition)
+	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
-	--Treated as "Go-D/D"
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetCode(EFFECT_ADD_SETCODE)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTargetRange(LOCATION_ONFIELD,LOCATION_ONFIELD)
-	e2:SetCondition(s.changecon)
-	e2:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,SET_DD))
-	e2:SetValue(0x20af)
-	c:RegisterEffect(e2)
 end
-s.listed_series={SET_DD,0x20af}
+s.listed_series={0xaf,0x20af}
+function s.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xaf)
+end
+function s.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_ONFIELD,0,5,nil)
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
-	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-	e1:SetReset(RESET_PHASE+PHASE_END)
-	e1:SetTargetRange(0,1)
-	Duel.RegisterEffect(e1,tp)
-end
-function s.changecon(e)
-	return Duel.IsExistingMatchingCard(aux.FaceupFilter(Card.IsSetCard,SET_DD),e:GetHandlerPlayer(),LOCATION_ONFIELD,0,5,nil)
+	local g=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	local tc=g:GetFirst()
+	for tc in aux.Next(g) do
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_ADD_SETCODE)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e1:SetValue(0x20af)
+		tc:RegisterEffect(e1)
+	end
+	local e2=Effect.CreateEffect(e:GetHandler())
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetReset(RESET_PHASE+PHASE_END)
+	e2:SetTargetRange(0,1)
+	Duel.RegisterEffect(e2,tp)
 end


### PR DESCRIPTION
https://yugipedia.com/wiki/Go-D/D_World

If you are submitting a bug fix, the pull request title should be of the form `Fix "CARD NAME"`.
In this case, replace this comment with a brief summary of your change. What did you fix?
---> Wrong effects. On a reread of the Arc-V Manga i realized issues with my card. First of all, making them "Go-D/D" isnt a continuous effect. After Reiji akaba makes 5 "D/D" cards "Go-D/D" monsters and turns pass, there can be multiple proof spotted on how it only makes them "Go-D/D" during activation. We see that "D/D/D Supersight King Zero Maxwell", "D/D/D Destiny King Zero Laplace", "D/D/D/D Super-Dimensional Sovereign Emperor Zero Paradox" are unaffected by the changes as their name stays the same. Meanwhile, even though Reiji loses out on the number of "D/D" monsters and falls below 5 cards, his previously changed "Go-D/D" cards still retain their name as they are destroyed by D/D/D/D. So i made changes to make it only on activation. And other than this there is still an issue that is out of my control. The "Go-D/D" archetype isnt added to the game yet so this could lead to issues with the card. I used 0x20af as hexcode for my card but you are free to use whatever. I apologize for the wrong card i had pull requested. Also the CDB needs to be changed to update the text.

- [X] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [X] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).

**New card checklist**

- [X] This card is not marked with a reason to not be added in the unofficial card tracker in `#card-scripting-101`.
Supervising staff member(s): _@larry126_
