### PR TITLE
Small improvement: Simplify redundant logic regarding the ternary 'or'

### DIFF
--- a/proc_ritual.lua
+++ b/proc_ritual.lua
@@ -40,7 +40,7 @@ function Ritual.WholeLevelTributeValue(cond)
 	return function(e,c)
 		local lv=e:GetHandler():GetLevel()
 		if cond(c,e) then
-			local clv=Ritual.SummoningLevel and Ritual.SummoningLevel or c:GetLevel()
+			local clv=Ritual.SummoningLevel or c:GetLevel()
 			return (lv<<16)|clv
 		else return lv end
 	end

--- a/proc_workaround.lua
+++ b/proc_workaround.lua
@@ -166,7 +166,7 @@ function Duel.CheckReleaseGroupCost(tp,f,minc,maxc,use_hand,check,ex,...)
 		maxc,use_hand,check,ex=minc,maxc,use_hand,check
 	end
 	if not ex then ex=Group.CreateGroup() end
-	local mg=Duel.GetReleaseGroup(tp,use_hand):Match(f and f or aux.TRUE,ex,table.unpack(params))
+	local mg=Duel.GetReleaseGroup(tp,use_hand):Match(f or aux.TRUE,ex,table.unpack(params))
 	local g,exg=mg:Split(Auxiliary.ReleaseCostFilter,nil,tp)
 	local specialchk=Auxiliary.MakeSpecialCheck(check,tp,exg,table.unpack(params))
 	local mustg=g:Match(function(c,tp)return c:IsHasEffect(EFFECT_EXTRA_RELEASE) and c:IsControler(1-tp)end,nil,tp)
@@ -175,7 +175,7 @@ function Duel.CheckReleaseGroupCost(tp,f,minc,maxc,use_hand,check,ex,...)
 end
 function Duel.SelectReleaseGroupCost(tp,f,minc,maxc,use_hand,check,ex,...)
 	if not ex then ex=Group.CreateGroup() end
-	local mg=Duel.GetReleaseGroup(tp,use_hand):Match(f and f or aux.TRUE,ex,...)
+	local mg=Duel.GetReleaseGroup(tp,use_hand):Match(f or aux.TRUE,ex,...)
 	local g,exg=mg:Split(Auxiliary.ReleaseCostFilter,nil,tp)
 	local specialchk=Auxiliary.MakeSpecialCheck(check,tp,exg,...)
 	local mustg=g:Match(function(c,tp)return c:IsHasEffect(EFFECT_EXTRA_RELEASE) and c:IsControler(1-tp)end,nil,tp)

--- a/unofficial/c151000000.lua
+++ b/unofficial/c151000000.lua
@@ -195,7 +195,7 @@ if not ActionDuel then
 	function ActionDuel.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		local c=e:GetHandler()
 		local originalField=e:GetLabelObject():GetLabelObject()
-		local t=string.find(originalField.af,'m') and originalField.tableAction or (c.tableAction and c.tableAction or (originalField.tableAction and originalField.tableAction or tableActionGeneric))
+		local t=(string.find(originalField.af,'m') and originalField.tableAction) or c.tableAction or (originalField.tableAction or tableActionGeneric
 		if chk==0 then return #t>0 end
 		ac=Duel.GetRandomNumber(1,#t)
 		e:SetLabel(t[ac])

--- a/utility.lua
+++ b/utility.lua
@@ -310,8 +310,8 @@ function Card.IsColumn(c,seq,tp,loc)
 	if not c:IsOnField() then return false end
 	local cseq=c:GetSequence()
 	local seq=seq
-	local loc=loc and loc or c:GetLocation()
-	local tp=tp and tp or c:GetControler()
+	local loc=loc or c:GetLocation()
+	local tp=tp or c:GetControler()
 	if c:IsLocation(LOCATION_MZONE) then
 		if cseq==5 then cseq=1 end
 		if cseq==6 then cseq=3 end
@@ -332,9 +332,9 @@ function Card.IsColumn(c,seq,tp,loc)
 end
 
 function Card.UpdateAttack(c,amt,reset,rc)
-	rc=rc and rc or c
+	rc=rc or c
 	local r=(c==rc) and RESETS_STANDARD_DISABLE or RESETS_STANDARD
-	reset=reset and reset or RESET_EVENT+r
+	reset=reset or RESET_EVENT+r
 	local atk=c:GetAttack()
 	if atk>=-amt then --If amt is positive, it would become negative and always be lower than or equal to atk, if amt is negative, it would become postive and if it is too much it would be higher than atk
 		local e1=Effect.CreateEffect(rc)
@@ -352,9 +352,9 @@ function Card.UpdateAttack(c,amt,reset,rc)
 end
 
 function Card.UpdateDefense(c,amt,reset,rc)
-	rc=rc and rc or c
+	rc=rc or c
 	local r=(c==rc) and RESETS_STANDARD_DISABLE or RESETS_STANDARD
-	reset=reset and reset or RESET_EVENT+r
+	reset=reset or RESET_EVENT+r
 	local def=c:GetDefense()
 	if def and def>=-amt then --See Card.UpdateAttack
 		local e1=Effect.CreateEffect(rc)
@@ -372,9 +372,9 @@ function Card.UpdateDefense(c,amt,reset,rc)
 end
 
 function Card.UpdateLevel(c,amt,reset,rc)
-	rc=rc and rc or c
+	rc=rc or c
 	local r=(c==rc) and RESETS_STANDARD_DISABLE or RESETS_STANDARD
-	reset=reset and reset or RESET_EVENT+r
+	reset=reset or RESET_EVENT+r
 	local lv=c:GetLevel()
 	if c:IsLevelBelow(2147483647) then
 		if lv+amt<=0 then amt=-(lv-1) end --Unlike ATK, if amt is too much should reduce as much as possible
@@ -390,9 +390,9 @@ function Card.UpdateLevel(c,amt,reset,rc)
 end
 
 function Card.UpdateRank(c,amt,reset,rc)
-	rc=rc and rc or c
+	rc=rc or c
 	local r=(c==rc) and RESETS_STANDARD_DISABLE or RESETS_STANDARD
-	reset=reset and reset or RESET_EVENT+r
+	reset=reset or RESET_EVENT+r
 	local rk=c:GetRank()
 	if c:IsRankBelow(2147483647) then
 		if rk+amt<=0 then amt=-(rk-1) end --See Card.UpdateLevel
@@ -408,9 +408,9 @@ function Card.UpdateRank(c,amt,reset,rc)
 end
 
 function Card.UpdateLink(c,amt,reset,rc)
-	rc=rc and rc or c
+	rc=rc or c
 	local r=(c==rc) and RESETS_STANDARD_DISABLE or RESETS_STANDARD
-	reset=reset and reset or RESET_EVENT+r
+	reset=reset or RESET_EVENT+r
 	local lk=c:GetLink()
 	if c:IsLinkBelow(2147483647) then
 		if lk+amt<=0 then amt=-(lk-1) end --See Card.UpdateLevel
@@ -426,9 +426,9 @@ function Card.UpdateLink(c,amt,reset,rc)
 end
 
 function Card.UpdateScale(c,amt,reset,rc)
-	rc=rc and rc or c
+	rc=rc or c
 	local r=(c==rc) and RESETS_STANDARD_DISABLE or RESETS_STANDARD
-	reset=reset and reset or RESET_EVENT+r
+	reset=reset or RESET_EVENT+r
 	local scl=c:GetLeftScale()
 	if scl then
 		if scl+amt<=0 then amt = -(scl-1) end --See Card.UpdateLevel
@@ -783,7 +783,7 @@ function Auxiliary.GetExtraMaterials(tp,mustg,sc,summon_type)
 			local eg=te:GetValue()(0,summon_type,te,tp,sc)-mustg
 			eg:KeepAlive()
 			tg=tg+eg
-			local efun=te:GetOperation() and te:GetOperation() or aux.TRUE
+			local efun=te:GetOperation() or aux.TRUE
 			table.insert(t,{eg,efun,te})
 		end
 	end
@@ -1316,7 +1316,7 @@ function Auxiliary.SelectUnselectGroup(g,e,tp,minc,maxc,rescon,chk,seltp,hintmsg
 		end
 		return false
 	end
-	local hintmsg=hintmsg and hintmsg or 0
+	local hintmsg=hintmsg or 0
 	local sg=Group.CreateGroup()
 	while true do
 		local finishable = #sg>=minc and (not finishcon or finishcon(sg,e,tp,g))


### PR DESCRIPTION
There were many cases of the pattern `x and x or y`. Due to operator precedence this is evaluated as `(x and x) or y`. Since `x and x` is equivalent to `x` itself this can be simplified, improving clarity and sometimes removing unnecessary function calls. (don't know if Lua would optimize them anyways though)

<!--
Hello, thanks for submitting a pull request! Please provide enough information so we can review it.

If you are submitting an addition to the unofficial script project, the pull request title should be
of the form `Add "CARD NAME"`. Replace this comment with a Yugipedia link.

If you are submitting a bug fix, the pull request title should be of the form `Fix "CARD NAME"`.
In this case, replace this comment with a brief summary of your change. What did you fix?
--->

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [ ] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
