### PR TITLE
Unofficial Fixes

### DIFF
--- a/unofficial/c100000069.lua
+++ b/unofficial/c100000069.lua
@@ -2,7 +2,7 @@
 --Dark Summoning Beast (VG)
 local s,id=GetID()
 function s.initial_effect(c)
-	--spsummon
+	--Special Summon 1 of Uria, Hamon, or Raviel from your Graveyard
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -21,10 +21,10 @@ function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.Release(c,REASON_COST)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
-	e1:SetCode(EFFECT_CANNOT_ATTACK)
-	e1:SetProperty(EFFECT_FLAG_OATH+EFFECT_FLAG_IGNORE_IMMUNE)
-	e1:SetTargetRange(LOCATION_MZONE,0)
-	e1:SetReset(RESET_PHASE+PHASE_END)
+	e1:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+	e1:SetProperty(EFFECT_FLAG_OATH+EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetReset(RESET_PHASE|PHASE_END)
 	Duel.RegisterEffect(e1,tp)
 end
 function s.filter(c,e,tp)
@@ -32,16 +32,14 @@ function s.filter(c,e,tp)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and s.filter(chkc,e,tp) end
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if e:GetHandler():GetSequence()<5 then ft=ft+1 end
-	if chk==0 then return ft>0 and Duel.IsExistingTarget(s.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	if chk==0 then return Duel.GetMZoneCount(tp,e:GetHandler())>0 and Duel.IsExistingTarget(s.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) then
 		Duel.SpecialSummon(tc,0,tp,tp,true,false,POS_FACEUP)
 	end
 end

--- a/unofficial/c150000034.lua
+++ b/unofficial/c150000034.lua
@@ -2,58 +2,44 @@
 --Illumination
 local s,id=GetID()
 function s.initial_effect(c)
-	--damage
+	--Activate 1 of these effects for the rest of this turn
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetOperation(s.activate1)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
-	--destroy
-	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(id,1))
-	e2:SetCode(EVENT_FREE_CHAIN)
-	e2:SetOperation(s.activate2)
-	c:RegisterEffect(e2)
-end
-function s.activate1(e,tp,eg,ep,ev,re,r,rp)
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e1:SetCode(EVENT_CHAINING)
-	e1:SetCondition(s.condition1)
-	e1:SetTarget(s.target)
-	e1:SetOperation(s.operation)
-	e1:SetCountLimit(1)
-	e1:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e1,tp)
-end
-function s.condition1(e,tp,eg,ep,ev,re,r,rp)
-	if tp==ep or not Duel.IsChainNegatable(ev) then return false end
-	if not re:IsActiveType(TYPE_MONSTER) and not re:IsHasType(EFFECT_TYPE_ACTIVATE) then return false end
-	local ex,tg,tc=Duel.GetOperationInfo(ev,CATEGORY_DISABLE_SUMMON)
-	return ex and tg~=nil and tc+tg:FilterCount(s.cfilter,nil)-#tg>0
-end
-function s.activate2(e,tp,eg,ep,ev,re,r,rp)
-	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e1:SetCode(EVENT_CHAINING)
-	e1:SetCondition(s.condition2)
-	e1:SetTarget(s.target)
-	e1:SetOperation(s.operation)
-	e1:SetCountLimit(1)
-	e1:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e1,tp)
-end
-function s.condition2(e,tp,eg,ep,ev,re,r,rp)
-	if tp==ep or not Duel.IsChainNegatable(ev) then return false end
-	if not re:IsActiveType(TYPE_MONSTER) and not re:IsHasType(EFFECT_TYPE_ACTIVATE) then return false end
-	local ex,tg,tc=Duel.GetOperationInfo(ev,CATEGORY_DESTROY)
-	return ex and tg~=nil and tc+tg:FilterCount(s.cfilter,nil)-#tg>0
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	local op=Duel.SelectOption(tp,aux.Stringid(id,1),aux.Stringid(id,2))
+	e:SetLabel(op)
+end
+function s.activate(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_CHAIN_SOLVING)
+	if e:GetLabel()==0 then
+		--Negate an effect that would negate a Normal or Special Summon
+		e1:SetCondition(s.condition1)
+	else
+		--Negate an effect that would destroy a monster(s)
+		e1:SetCondition(s.condition2)
+	end
+	e1:SetOperation(s.operation)
+	e1:SetCountLimit(1)
+	e1:SetReset(RESET_PHASE|PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function s.condition1(e,tp,eg,ep,ev,re,r,rp)
+	local ex,tg=Duel.GetOperationInfo(ev,CATEGORY_DISABLE_SUMMON)
+	return ex and tg~=nil and tg:IsExists(Card.IsSummonType,1,nil,SUMMON_TYPE_NORMAL|SUMMON_TYPE_SPECIAL) 
+end
+function s.condition2(e,tp,eg,ep,ev,re,r,rp)
+	local ex,tg,tc=Duel.GetOperationInfo(ev,CATEGORY_DESTROY)
+	return ex and tg~=nil and tc+tg:FilterCount(Card.IsMonster,nil)-#tg>0
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
-	Duel.NegateActivation(ev)
+	Duel.NegateEffect(ev)
 end

--- a/unofficial/c511000171.lua
+++ b/unofficial/c511000171.lua
@@ -1,40 +1,49 @@
+--マジック・サンクチュアリ
 --Spell Sanctuary
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Each player adds 1 Spell from their Deck to their hand
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 	--wut
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
-	e2:SetCode(EFFECT_BECOME_QUICK)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetTargetRange(0x3f,0x3f)
-	e2:SetTarget(aux.TargetBoolFunction(Card.IsSpell))
-	c:RegisterEffect(e2)
+	local e2a=Effect.CreateEffect(c)
+	e2a:SetType(EFFECT_TYPE_FIELD)
+	e2a:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e2a:SetCode(EFFECT_BECOME_QUICK)
+	e2a:SetRange(LOCATION_SZONE)
+	e2a:SetTargetRange(LOCATION_ONFIELD,LOCATION_ONFIELD)
+	e2a:SetTarget(function(e,c) return c:IsSpell() and not c:IsType(TYPE_QUICKPLAY) and c:IsFacedown() and Duel.GetTurnPlayer()~=c:GetControler() end)
+	c:RegisterEffect(e2a)
+	local e2b=e2a:Clone()
+	e2b:SetCode(EFFECT_QP_ACT_IN_SET_TURN)
+	e2b:SetTarget(function(e,c) return c:IsSpell() and not c:IsType(TYPE_QUICKPLAY) and c:IsHasEffect(EFFECT_BECOME_QUICK) and Duel.GetTurnPlayer()~=c:GetControler() end)
+	c:RegisterEffect(e2b)
 end
 function s.filter(c)
 	return c:IsSpell() and c:IsAbleToHand()
 end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+	Duel.SetPossibleOperationInfo(0,CATEGORY_TOHAND,nil,1,1-tp,LOCATION_DECK)
+end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	if not e:GetHandler():IsRelateToEffect(e) then return end
-	local g1=Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK,0,nil)
-	if #g1>0 and Duel.SelectYesNo(tp,aux.Stringid(24140059,0)) then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-		local sg=g1:Select(tp,1,1,nil)
-		Duel.SendtoHand(sg,nil,REASON_EFFECT)
-		Duel.ConfirmCards(1-tp,sg)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g1=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if #g1>0 then
+		Duel.SendtoHand(g1,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g1)
 	end
-	local g2=Duel.GetMatchingGroup(s.filter,1-tp,LOCATION_DECK,0,nil)
-	if #g2>0 and Duel.SelectYesNo(1-tp,aux.Stringid(24140059,0)) then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
-		local sg=g2:Select(1-tp,1,1,nil)
-		Duel.SendtoHand(sg,nil,REASON_EFFECT)
-		Duel.ConfirmCards(tp,sg)
+	Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_ATOHAND)
+	local g2=Duel.SelectMatchingCard(1-tp,s.filter,1-tp,LOCATION_DECK,0,1,1,nil)
+	if #g2>0 then
+		Duel.SendtoHand(g2,nil,REASON_EFFECT)
+		Duel.ConfirmCards(tp,g2)
 	end
 end

--- a/unofficial/c511000615.lua
+++ b/unofficial/c511000615.lua
@@ -1,25 +1,26 @@
+--シンクロ・バリア・フォース
 --Synchro Barrier Force
 local s,id=GetID()
 function s.initial_effect(c)
-	--Negate
+	--Negate an effect that would destroy a card on the field, then inflict damage
 	local e1=Effect.CreateEffect(c)
-	e1:SetCategory(CATEGORY_NEGATE+CATEGORY_DAMAGE)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_DISABLE+CATEGORY_DAMAGE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_CHAINING)
-	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
 	e1:SetCondition(s.condition)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	if not Duel.IsChainNegatable(ev) then return false end
+	if not Duel.IsChainDisablable(ev) then return false end
 	local ex,tg,tc=Duel.GetOperationInfo(ev,CATEGORY_DESTROY)
-	return ex and tg~=nil and tc>0
+	return ex and tg~=nil and tc+tg:FilterCount(Card.IsOnField,nil)-#tg>0
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 	local dam=Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_MZONE,0,nil)*500
 	Duel.SetTargetPlayer(1-tp)
 	Duel.SetTargetParam(dam)
@@ -29,8 +30,10 @@ function s.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_SYNCHRO)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
-	Duel.NegateActivation(ev)
-	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
-	local dam=Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_MZONE,0,nil)*500
-	Duel.Damage(p,dam,REASON_EFFECT)
+	if Duel.NegateEffect(ev) then
+		Duel.BreakEffect()
+		local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+		local dam=Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_MZONE,0,nil)*500
+		Duel.Damage(p,dam,REASON_EFFECT)
+	end
 end

--- a/unofficial/c511000631.lua
+++ b/unofficial/c511000631.lua
@@ -1,8 +1,8 @@
 --フラットＬＶ４
---Flat LV4
+--Flat Lv 4
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Each player can Special Summon 1 Level 4 monster from their Deck
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -21,26 +21,30 @@ function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.cfilter,1,nil,tp)
 end
 function s.filter(c,e,tp)
-	return c:GetLevel()==4 and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+	Duel.SetPossibleOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,1-tp,LOCATION_DECK)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil,e,tp)
-		and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 		local g1=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
-		Duel.SpecialSummonStep(g1:GetFirst(),0,tp,tp,false,false,POS_FACEUP)
+		if #g1>0 then
+			Duel.SpecialSummonStep(g1:GetFirst(),0,tp,tp,false,false,POS_FACEUP)
+		end
 	end
 	if Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(s.filter,1-tp,LOCATION_DECK,0,1,nil,e,1-tp)
 		and Duel.SelectYesNo(1-tp,aux.Stringid(id,1)) then
 		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_SPSUMMON)
 		local g2=Duel.SelectMatchingCard(1-tp,s.filter,1-tp,LOCATION_DECK,0,1,1,nil,e,1-tp)
-		Duel.SpecialSummonStep(g2:GetFirst(),0,1-tp,1-tp,false,false,POS_FACEUP)
+		if #g2>0 then
+			Duel.SpecialSummonStep(g2:GetFirst(),0,1-tp,1-tp,false,false,POS_FACEUP)
+		end
 	end
 	Duel.SpecialSummonComplete()
 end

--- a/unofficial/c511001901.lua
+++ b/unofficial/c511001901.lua
@@ -1,8 +1,10 @@
+--シールド・ウォール
 --Shield Wall
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Special Summon 4 "Shield Tokens"
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOKEN)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
@@ -23,19 +25,28 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		for i=1,4 do
 			local token=Duel.CreateToken(tp,id+1)
 			Duel.SpecialSummonStep(token,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
+			--Cannot attack
 			local e1=Effect.CreateEffect(e:GetHandler())
 			e1:SetType(EFFECT_TYPE_SINGLE)
-			e1:SetCode(EFFECT_UNRELEASABLE_SUM)
+			e1:SetCode(EFFECT_CANNOT_ATTACK)
 			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-			e1:SetValue(1)
-			e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+			e1:SetReset(RESET_EVENT|RESETS_STANDARD)
 			token:RegisterEffect(e1,true)
+			--Cannot be tributed for a Tribute Summon
 			local e2=Effect.CreateEffect(e:GetHandler())
-			e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
-			e2:SetCode(EVENT_CHANGE_POS)
-			e2:SetOperation(s.desop)
-			e2:SetReset(RESET_EVENT+RESETS_STANDARD)
-			token:RegisterEffect(e2)
+			e2:SetType(EFFECT_TYPE_SINGLE)
+			e2:SetCode(EFFECT_UNRELEASABLE_SUM)
+			e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e2:SetValue(1)
+			e2:SetReset(RESET_EVENT|RESETS_STANDARD)
+			token:RegisterEffect(e2,true)
+			--If changed to Attack Position, destroy it
+			local e3=Effect.CreateEffect(e:GetHandler())
+			e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+			e3:SetCode(EVENT_CHANGE_POS)
+			e3:SetOperation(s.desop)
+			e3:SetReset(RESET_EVENT|RESETS_STANDARD)
+			token:RegisterEffect(e3)
 		end
 		Duel.SpecialSummonComplete()
 	end

--- a/unofficial/c511002379.lua
+++ b/unofficial/c511002379.lua
@@ -1,4 +1,4 @@
---摩天楼 －スカイスクレイパー－
+--摩天楼 －スカイスクレイパー－ (Anime)
 --Skyscraper (Anime)
 local s,id=GetID()
 function s.initial_effect(c)
@@ -7,29 +7,29 @@ function s.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	c:RegisterEffect(e1)
-	--atk up
+	--That battling "Elemental HERO" monster gains 1000 ATK during damage calculation only
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
 	e2:SetCode(EFFECT_UPDATE_ATTACK)
 	e2:SetRange(LOCATION_FZONE)
-	e2:SetTargetRange(LOCATION_MZONE,0)
+	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
 	e2:SetCondition(s.atkcon)
 	e2:SetTarget(s.atktg)
 	e2:SetValue(s.atkval)
 	c:RegisterEffect(e2)
 end
-s.listed_series={0x3008}
+s.listed_series={SET_ELEMENTAL_HERO}
 function s.atkcon(e)
 	s[0]=false
 	return Duel.GetCurrentPhase()==PHASE_DAMAGE_CAL and Duel.GetAttackTarget() and Duel.GetAttacker()
 end
 function s.atktg(e,c)
-	return (c==Duel.GetAttacker() and c:IsSetCard(0x3008)) or (c==Duel.GetAttackTarget() and c:IsSetCard(0x3008))
+	return (c==Duel.GetAttacker() and c:IsSetCard(SET_ELEMENTAL_HERO)) or (c==Duel.GetAttackTarget() and c:IsSetCard(SET_ELEMENTAL_HERO))
 end
 function s.atkval(e,c)
 	local d=Duel.GetAttackTarget()
 	if d==c then d=Duel.GetAttacker() end
-	if s[0] or c:GetAttack()<d:GetAttack() then
+	if s[0] or (c:GetAttack()<d:GetAttack() and d:IsControler(1-e:GetHandlerPlayer())) then
 		s[0]=true
 		return 1000
 	else return 0 end

--- a/unofficial/c511002520.lua
+++ b/unofficial/c511002520.lua
@@ -14,42 +14,39 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 s.listed_names={CARD_STARDUST_DRAGON}
-function s.cfilter(c,p)
-	return c:GetControler()==p and c:IsOnField()
+function s.cfilter(c,tp)
+	return c:IsControler(tp) and c:IsOnField()
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	if tp==ep or not Duel.IsChainDisablable(ev) then return false end
 	local ex,tg,tc=Duel.GetOperationInfo(ev,CATEGORY_DESTROY)
 	return ex and tg~=nil and tc+tg:FilterCount(s.cfilter,nil,tp)-#tg>1
 end
-function s.filter(c,e,tp)
-	return c:IsCode(CARD_STARDUST_DRAGON) and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_SYNCHRO,tp,false,false)
-		and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0
+function s.spfilter(c,e,tp)
+	return c:IsCode(CARD_STARDUST_DRAGON) and Duel.GetLocationCountFromEx(tp,tp,nil,c)>0
+		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_SYNCHRO,tp,false,false)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local pg=aux.GetMustBeMaterialGroup(tp,Group.CreateGroup(),tp,nil,nil,REASON_SYNCHRO)
-		return #pg<=0 and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp)
+		return #pg<=0 and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp)
 	end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
-	if re:GetHandler():IsRelateToEffect(re) then
+	local rc=re:GetHandler()
+	if rc:IsDestructable() and rc:IsRelateToEffect(re) then
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+		Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 	end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local tc=re:GetHandler()
-	if not tc:IsDisabled() then
-		Duel.NegateEffect(ev)
-		local pg=aux.GetMustBeMaterialGroup(tp,Group.CreateGroup(),tp,nil,nil,REASON_SYNCHRO)
-		if tc:IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)~=0 and #pg<=0 then
-			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-			local tc=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp):GetFirst()
-			if tc then
-				Duel.BreakEffect()
-				Duel.SpecialSummon(tc,SUMMON_TYPE_SYNCHRO,tp,tp,false,false,POS_FACEUP)
-				tc:CompleteProcedure()
-			end
+	local pg=aux.GetMustBeMaterialGroup(tp,Group.CreateGroup(),tp,nil,nil,REASON_SYNCHRO)
+	if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)>0 and #pg<=0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tc=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp):GetFirst()
+		if tc then
+			Duel.BreakEffect()
+			Duel.SpecialSummon(tc,SUMMON_TYPE_SYNCHRO,tp,tp,false,false,POS_FACEUP)
+			tc:CompleteProcedure()
 		end
 	end
 end

--- a/unofficial/c511002532.lua
+++ b/unofficial/c511002532.lua
@@ -3,8 +3,9 @@
 --fixed by Larry126
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Each player can Special Summon 1 Spellcaster monster from their Deck
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
@@ -21,7 +22,7 @@ function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.PayLPCost(tp,math.floor(Duel.GetLP(tp)/2))
 	local p=tp
 	if Duel.IsExistingMatchingCard(s.spfilter,1-tp,LOCATION_DECK,0,1,nil,e,1-tp) 
-		and Duel.SelectYesNo(1-tp,aux.Stringid(102380,0)) then
+		and Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0 and Duel.SelectYesNo(1-tp,aux.Stringid(id,1)) then
 		Duel.PayLPCost(1-tp,math.floor(Duel.GetLP(1-tp)/2))
 		p=tp+1
 	end
@@ -29,8 +30,7 @@ function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) 
-		and Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0 and Duel.IsPlayerCanSpecialSummon(1-tp) end
+		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) end
 	local p=e:GetLabel()
 	if p~=tp then
 		p=PLAYER_ALL

--- a/unofficial/c511007022.lua
+++ b/unofficial/c511007022.lua
@@ -15,37 +15,32 @@ function s.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_DRAW)
-	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-	e2:SetCode(EVENT_TO_GRAVE)
-	e2:SetCondition(function(e) return e:GetHandler():IsReason(REASON_DESTROY) end)
+	e2:SetCode(EVENT_DESTROYED)
 	e2:SetTarget(s.target)
 	e2:SetOperation(s.operation)
 	c:RegisterEffect(e2)
 	--Double Snare
-	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_SINGLE)
-	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
-	e3:SetRange(LOCATION_MZONE)
-	e3:SetCondition(s.discon)
-	e3:SetCode(3682106)
-	c:RegisterEffect(e3)
+	aux.DoubleSnareValidity(c,LOCATION_MZONE)
 end
 function s.discon(e)
 	return e:GetHandler():IsAttackPos()
 end
 function s.disfilter(c,p)
-	return c:IsControler(p) and c:IsFaceup() and c:IsRace(RACE_MACHINE)
+	return c:IsControler(p) and c:IsLocation(LOCATION_MZONE)
 end
 function s.disop(e,tp,eg,ep,ev,re,r,rp)
 	if re:IsMonsterEffect() or not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
 	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
-	if g:IsExists(s.disfilter,1,nil,tp) and Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(id,1)) then
-		Duel.NegateEffect(ev)
+	if #g==1 and g:IsExists(s.disfilter,1,nil,tp) and Duel.SelectEffectYesNo(tp,e:GetHandler(),aux.Stringid(id,1)) then
+		if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
+			Duel.Destroy(re:GetHandler(),REASON_EFFECT)
+		end
 	end
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
+	if chk==0 then return true end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(1)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)

--- a/unofficial/c511600052.lua
+++ b/unofficial/c511600052.lua
@@ -1,18 +1,17 @@
 --エルフの聖剣士 (Anime)
 --Celtic Guard of Noble Arms (Anime)
 --scripted by Larry126
-Duel.LoadScript("c420.lua")
 local s,id=GetID()
 function s.initial_effect(c)
-	--cannot attack
+	--Cannot attack while you have any cards in your hand
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_CANNOT_ATTACK)
 	e1:SetCondition(s.atcon)
 	c:RegisterEffect(e1)
-	--spsummon
+	--Special Summon 1 Level 4 EARTH Warrior monster from your hand
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(45531624,0))
+	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_MZONE)
@@ -20,11 +19,11 @@ function s.initial_effect(c)
 	e2:SetTarget(s.sptg)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
-	--draw
+	--Draw cards equal to the number of Level 4 EARTH Warrior monsters you control
 	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,1))
 	e3:SetCategory(CATEGORY_DRAW)
-	e3:SetDescription(aux.Stringid(45531624,1))
-	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
 	e3:SetCode(EVENT_BATTLE_DAMAGE)
 	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e3:SetCondition(s.drcon)
@@ -36,7 +35,7 @@ function s.atcon(e)
 	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),LOCATION_HAND,0)>=1
 end
 function s.spfilter(c,e,tp)
-	return c:IsElf() and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+	return c:IsLevel(4) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsRace(RACE_WARRIOR) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
@@ -55,13 +54,12 @@ function s.drcon(e,tp,eg,ep,ev,re,r,rp)
 	return ep~=tp
 end
 function s.drfilter(c)
-	return c:IsFaceup() and c:IsElf()
+	return c:IsFaceup() and c:IsLevel(4) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsRace(RACE_WARRIOR)
 end
 function s.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ct=Duel.GetMatchingGroupCount(s.drfilter,tp,LOCATION_MZONE,0,nil)
-	if chk==0 then return ct>0 and Duel.IsPlayerCanDraw(tp,ct) end
+	if chk==0 then return true end
 	Duel.SetTargetPlayer(tp)
-	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,ct)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,Duel.GetMatchingGroupCount(s.drfilter,tp,LOCATION_MZONE,0,nil))
 end
 function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)


### PR DESCRIPTION
1. https://ms.yugipedia.com//thumb/4/4f/LordofDarkSummons-TFSP-JP-VG-info.png/400px-LordofDarkSummons-TFSP-JP-VG-info.png - Should be preventing attack declarations instead of attacks

2. Overhauled Illumination so that it functions and does what it is supposed to do

3. https://yugipedia.com/wiki/Spell_Sanctuary - Adding the Spells should be mandatory and reinterpreted the other effect based on the BC rule of Set Spells being usable as Quick-Play Spells during each player's opponent's turns.

4. Corrected Synchro Barrier Force to negate the effect instead of the activation and corrected to properly function as a "then" effect

5. https://yugipedia.com/wiki/Flat_Lv_4 (ignore the en lore) - Updated to require the user to summon a monster in accordance to rulings for Crashbug Road. Also note that this card should be renamed from "Flat LV4" to "Flat Lv 4"
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=9667&request_locale=ja

6. https://yugipedia.com/wiki/Shield_Wall - The tokens should not be able to attack

7. https://cdn.discordapp.com/attachments/433572408746573844/998797228632199259/AU_RAW_Yu-Gi-OhGX_019_DVDrip_480p_x264_AC3.mkv-00.03.54.109-1.png
https://cdn.discordapp.com/attachments/433572408746573844/998797252892041216/AU_RAW_Yu-Gi-OhGX_030_DVDrip_480p_x264_AC3.mkv-00.17.39.642-1.png
https://cdn.discordapp.com/attachments/433572408746573844/998797272554930256/AU_RAW_Yu-Gi-OhGX_034_DVDrip_480p_x264_AC3.mkv-00.14.16.647-1.png

The condition for Skyscraper should be "If an "Elemental HERO" monster battles an opponent's monster that has a higher ATK". I have somewhat better quality screenshots if needed.

8. Fixed Starlight Road to be able to proceed with the rest of the effect even if the effect it is trying to negate is already negated and restyled the script a bit based on the current OCG script
https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=12361&keyword=&tag=-1

9. Fixed a bug where Dark Magic Curtain couldn't be activated if the opponent has no open zones and added this check to where it checks if the opponent can pay the cost

10. https://yugipedia.com/wiki/Cyber_Phoenix_(anime) - Should be able to protect non machine monsters too, destroy the cards it negates, and the draw should be mandatory and not require being sent to the graveyard. Comparing to the OCG text also suggests it should only work on effects that target 1 monster you control and no other cards. I have the screenshots that were used to make out the lore if anyone wants to verify the transcription is correct

11. https://web.archive.org/web/20230221133359/https://yugipedia.com/wiki/Celtic_Guard_of_Noble_Arms_(anime) - Updated to function based on the movie text instead of MM text

I am a bit suspicious as to whether Sanctuary, Flat, and Curtain should have the turn player perform the action both players will/can do first instead of the user of the card, but I could not find rulings of cards that seemed close enough to say

- [ ] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [ ] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
