### PR TITLE
Fix TF3 Gods

### DIFF
--- a/unofficial/c110000011.lua
+++ b/unofficial/c110000011.lua
@@ -2,10 +2,10 @@
 --Obelisk the Tormentor (VG)
 local s,id=GetID()
 function s.initial_effect(c)
-	--summon with 3 tribute
+	--Must be Normal Summoned/Set by Tributing 3 monsters
 	local e1=aux.AddNormalSummonProcedure(c,true,false,3,3)
-	local e2=aux.AddNormalSetProcedure(c)
-	--cannot be target
+	local e2=aux.AddNormalSetProcedure(c,true,false,3,3)
+	--Neither player can target this card with card effects
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
@@ -13,7 +13,7 @@ function s.initial_effect(c)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetValue(1)
 	c:RegisterEffect(e3)
-	--to grave
+	--Send this Special Summoned card to the Graveyard
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(id,0))
 	e4:SetCategory(CATEGORY_TOGRAVE)
@@ -25,7 +25,7 @@ function s.initial_effect(c)
 	e4:SetTarget(s.tgtg)
 	e4:SetOperation(s.tgop)
 	c:RegisterEffect(e4)
-	--destroy
+	--Destroy all monsters your opponent controls
 	local e5=Effect.CreateEffect(c)
 	e5:SetDescription(aux.Stringid(id,1))
 	e5:SetCategory(CATEGORY_DESTROY)

--- a/unofficial/c511027028.lua
+++ b/unofficial/c511027028.lua
@@ -2,10 +2,10 @@
 --The Winged Dragon of Ra (TF3)
 local s,id=GetID()
 function s.initial_effect(c)
-	--summon with 3 tribute
+	--Must be Normal Summoned/Set by Tributing 3 monsters
 	local e1=aux.AddNormalSummonProcedure(c,true,false,3,3)
-	local e2=aux.AddNormalSetProcedure(c)
-	--cannot be target
+	local e2=aux.AddNormalSetProcedure(c,true,false,3,3)
+	--Neither player can target this card with card effects
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
@@ -13,7 +13,7 @@ function s.initial_effect(c)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetValue(1)
 	c:RegisterEffect(e3)
-	--to grave
+	--Send this Special Summoned card to the Graveyard
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(id,0))
 	e4:SetCategory(CATEGORY_TOGRAVE)
@@ -25,24 +25,23 @@ function s.initial_effect(c)
 	e4:SetTarget(s.tgtg)
 	e4:SetOperation(s.tgop)
 	c:RegisterEffect(e4)
-	--tribute check
+	--This card's ATK/DEF become the combined original ATK/DEF of the Tributes
 	local e5=Effect.CreateEffect(c)
 	e5:SetType(EFFECT_TYPE_SINGLE)
 	e5:SetCode(EFFECT_MATERIAL_CHECK)
 	e5:SetValue(s.valcheck)
 	c:RegisterEffect(e5)
-	--give atk effect only when summon
 	local e6=Effect.CreateEffect(c)
 	e6:SetType(EFFECT_TYPE_SINGLE)
 	e6:SetCode(EFFECT_SUMMON_COST)
 	e6:SetOperation(s.facechk)
 	e6:SetLabelObject(e5)
 	c:RegisterEffect(e6)
-	--destroy
+	--Destroy 1 monster on the field, and if you do, banish it
 	local e7=Effect.CreateEffect(c)
 	e7:SetDescription(aux.Stringid(id,1))
 	e7:SetCategory(CATEGORY_DESTROY)
-	e7:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_CARD_TARGET)
+	e7:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e7:SetCountLimit(1,0,EFFECT_COUNT_CODE_SINGLE)
 	e7:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_SINGLE)
 	e7:SetCode(EVENT_SPSUMMON_SUCCESS)
@@ -50,11 +49,10 @@ function s.initial_effect(c)
 	e7:SetTarget(s.destg)
 	e7:SetOperation(s.desop)
 	c:RegisterEffect(e7)
-	--pay atk/def
+	--This card gains ATK/DEF equal to the amount of LP paid
 	local e8=Effect.CreateEffect(c)
 	e8:SetDescription(aux.Stringid(id,2))
 	e8:SetCategory(CATEGORY_ATKCHANGE+CATEGORY_DEFCHANGE)
-	e8:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 	e8:SetCountLimit(1,0,EFFECT_COUNT_CODE_SINGLE)
 	e8:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_SINGLE)
 	e8:SetCode(EVENT_SPSUMMON_SUCCESS)
@@ -95,7 +93,7 @@ function s.valcheck(e,c)
 		e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 		e1:SetRange(LOCATION_MZONE)
 		e1:SetValue(atk)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD_DISABLE-RESET_TOFIELD)
+		e1:SetReset(RESET_EVENT|RESETS_STANDARD_DISABLE&~RESET_TOFIELD)
 		c:RegisterEffect(e1)
 		local e2=e1:Clone()
 		e2:SetCode(EFFECT_SET_DEFENSE)
@@ -120,7 +118,7 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) then
 		Duel.Destroy(tc,REASON_EFFECT,LOCATION_REMOVED)
 	end
 end
@@ -139,7 +137,7 @@ function s.adop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetRange(LOCATION_MZONE)
 		e1:SetCode(EFFECT_UPDATE_ATTACK)
 		e1:SetValue(e:GetLabel())
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD_DISABLE)
+		e1:SetReset(RESET_EVENT|RESETS_STANDARD_DISABLE)
 		c:RegisterEffect(e1)
 		local e2=e1:Clone()
 		e2:SetCode(EFFECT_UPDATE_DEFENSE)

--- a/unofficial/c511027029.lua
+++ b/unofficial/c511027029.lua
@@ -2,10 +2,10 @@
 --Slifer the Sky Dragon (TF3)
 local s,id=GetID()
 function s.initial_effect(c)
-	--summon with 3 tribute
+	--Must be Normal Summoned/Set by Tributing 3 monsters
 	local e1=aux.AddNormalSummonProcedure(c,true,false,3,3)
-	local e2=aux.AddNormalSetProcedure(c)
-	--cannot be target
+	local e2=aux.AddNormalSetProcedure(c,true,false,3,3)
+	--Neither player can target this card with card effects
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
@@ -13,7 +13,7 @@ function s.initial_effect(c)
 	e3:SetRange(LOCATION_MZONE)
 	e3:SetValue(1)
 	c:RegisterEffect(e3)
-	--to grave
+	--Send this Special Summoned card to the Graveyard
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(id,0))
 	e4:SetCategory(CATEGORY_TOGRAVE)
@@ -25,7 +25,7 @@ function s.initial_effect(c)
 	e4:SetTarget(s.tgtg)
 	e4:SetOperation(s.tgop)
 	c:RegisterEffect(e4)
-	--atk/def
+	--This card's ATK/DEF become the number of cards in your hand x 1000
 	local e5=Effect.CreateEffect(c)
 	e5:SetType(EFFECT_TYPE_SINGLE)
 	e5:SetCode(EFFECT_SET_ATTACK)
@@ -36,7 +36,7 @@ function s.initial_effect(c)
 	local e6=e5:Clone()
 	e6:SetCode(EFFECT_SET_DEFENSE)
 	c:RegisterEffect(e6)
-	--destroy
+	--Destroy that monster your opponent Normal or Flip Summons with 2000 or less DEF
 	local e7=Effect.CreateEffect(c)
 	e7:SetDescription(aux.Stringid(id,1))
 	e7:SetCategory(CATEGORY_DESTROY)


### PR DESCRIPTION
https://yugipedia.com/wiki/File:ObelisktheTormentor-GX06-JP-VG-info.png
https://yugipedia.com/wiki/File:TheWingedDragonofRa-GX06-JP-VG-info.png
https://yugipedia.com/wiki/File:SlifertheSkyDragon-GX06-JP-VG-info.png

Corrected to be able to be Normal Set. In addition to the wording supporting such, I have confirmed that they also function that way in TF3.

Also can somebody please relabel "The Winged Dragon of Ra (VG)" to "The Winged Dragon of Ra (TF4)?" That is the last game where that version of the card had that effect and this tag would be more helpful given there are multiple VG versions of Ra.

- [ ] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [ ] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
