### PR TITLE
Fix "Chain Destruction"

### DIFF
--- a/official/c1248895.lua
+++ b/official/c1248895.lua
@@ -19,7 +19,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e3)
 end
 function s.filter(c,e,tp)
-	if not (c:IsFaceup() and c:IsAttackBelow(12000) and (not e or c:IsCanBeEffectTarget(e))) then return false end
+	if not (c:IsFaceup() and c:IsAttackBelow(2000) and (not e or c:IsCanBeEffectTarget(e))) then return false end
 	local p=c:GetControler()
 	if p==tp then
 		return Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_DECK|LOCATION_HAND,0,1,nil,c:GetCode())

--- a/official/c1248895.lua
+++ b/official/c1248895.lua
@@ -18,8 +18,9 @@ function s.initial_effect(c)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e3)
 end
+
 function s.filter(c,e,tp)
-	if not (c:IsFaceup() and c:IsAttackBelow(2000) and (not e or c:IsCanBeEffectTarget(e))) then return false end
+	if not (c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsAttackBelow(2000) and (not e or c:IsCanBeEffectTarget(e))) then return false end
 	local p=c:GetControler()
 	if p==tp then
 		return Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_DECK|LOCATION_HAND,0,1,nil,c:GetCode())

--- a/official/c1248895.lua
+++ b/official/c1248895.lua
@@ -17,25 +17,64 @@ function s.initial_effect(c)
 	local e3=e1:Clone()
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e3)
+	--Hidden Token to check eligible names when Tokens/Extra Deck Monsters are Summoned
+	aux.GlobalCheck(s,function()
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_CONTINUOUS|EFFECT_TYPE_FIELD)
+		ge1:SetCode(EVENT_ADJUST)
+		ge1:SetCountLimit(1,id,EFFECT_COUNT_CODE_DUEL)
+		ge1:SetOperation(s.createtoken)
+		Duel.RegisterEffect(ge1,0)
+	end)
 end
-function s.filter(c,e)
-	return c:IsFaceup() and c:IsAttackBelow(2000) and c:IsCanBeEffectTarget(e)
+function s.filter(c,e,codechk)
+	return c:IsFaceup() and c:IsAttackBelow(2000) and (not e or c:IsCanBeEffectTarget(e)) and (not codechk or s.mdnamecheck(c))
+end
+function s.mdnamecheck(c)
+	if c:IsType(TYPE_TOKEN|TYPE_EXTRA) or c:IsHasEffect(EFFECT_CHANGE_CODE) then
+		local codes={c:GetCode()}
+		for _,code in ipairs(codes) do
+			s.CheckCodeToken:Recreate(code)
+			if not s.CheckCodeToken:IsType(TYPE_TOKEN|TYPE_EXTRA) then
+				return true
+			end
+		end
+		return false
+	end
+	return true
+end
+function s.publicfilter(c,p,...)
+	return c:IsCode(...) and (c:IsPublic() or (c:IsLocation(LOCATION_DECK) and c:GetSequence()==Duel.GetFieldGroupCount(p,LOCATION_DECK,0)-1 and Duel.IsPlayerAffectedByEffect(p,EFFECT_REVERSE_DECK)))
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return eg:IsContains(chkc) end
-	if chk==0 then return eg:IsExists(s.filter,1,nil,e) end
+	if chkc then return eg:IsContains(chkc) and s.filter(chkc,nil,true) end
+	if chk==0 then return eg:IsExists(s.filter,1,nil,e,true) end
+	local tc
 	if #eg==1 then
 		Duel.SetTargetCard(eg)
+		tc=eg:GetFirst()
 	else
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-		local g=eg:FilterSelect(tp,s.filter,1,1,nil,e)
+		local g=eg:FilterSelect(tp,s.filter,1,1,nil,e,true)
 		Duel.SetTargetCard(g)
+		tc=g:GetFirst()
+	end
+	local p=tc:GetControler()
+	local public=Duel.GetMatchingGroup(s.publicfilter,p,LOCATION_DECK|LOCATION_HAND,0,nil,p,tc:GetCode())
+	if #public>0 then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,public,#public,p,LOCATION_DECK|LOCATION_HAND)
+	else
+		Duel.SetPossibleOperationInfo(0,CATEGORY_DESTROY,nil,1,p,LOCATION_DECK|LOCATION_HAND)
 	end
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	local tpe=tc:GetType()
-	if (tpe&TYPE_TOKEN)~=0 then return end
-	local dg=Duel.GetMatchingGroup(Card.IsCode,tc:GetControler(),LOCATION_DECK+LOCATION_HAND,0,nil,tc:GetCode())
+	if not tc:IsRelateToEffect(e) or not tc:IsFaceup() then return end
+	local dg=Duel.GetMatchingGroup(Card.IsCode,tc:GetControler(),LOCATION_DECK|LOCATION_HAND,0,nil,tc:GetCode())
 	Duel.Destroy(dg,REASON_EFFECT)
+end
+
+function s.createtoken(e)
+	s.CheckCodeToken=Duel.CreateToken(0,0)
+	e:Reset()
 end

--- a/official/c1248895.lua
+++ b/official/c1248895.lua
@@ -17,30 +17,22 @@ function s.initial_effect(c)
 	local e3=e1:Clone()
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e3)
-	--Hidden Token to check eligible names when Tokens/Extra Deck Monsters are Summoned
-	aux.GlobalCheck(s,function()
-		local ge1=Effect.CreateEffect(c)
-		ge1:SetType(EFFECT_TYPE_CONTINUOUS|EFFECT_TYPE_FIELD)
-		ge1:SetCode(EVENT_ADJUST)
-		ge1:SetCountLimit(1,id,EFFECT_COUNT_CODE_DUEL)
-		ge1:SetOperation(s.createtoken)
-		Duel.RegisterEffect(ge1,0)
-	end)
 end
 function s.filter(c,e,tp)
-	if not (c:IsFaceup() and c:IsAttackBelow(2000) and (not e or c:IsCanBeEffectTarget(e))) then return false end
-	if c:IsControler(tp) then
+	if not (c:IsFaceup() and c:IsAttackBelow(12000) and (not e or c:IsCanBeEffectTarget(e))) then return false end
+	local p=c:GetControler()
+	if p==tp then
 		return Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_DECK|LOCATION_HAND,0,1,nil,c:GetCode())
 	else
-		return s.mdnamecheck(c)
+		return Duel.GetFieldGroupCount(p,LOCATION_HAND|LOCATION_DECK,0)>0 and s.mdnamecheck(c)
 	end
 end
 function s.mdnamecheck(c)
 	if c:IsType(TYPE_TOKEN|TYPE_EXTRA) or c:IsHasEffect(EFFECT_CHANGE_CODE) then
 		local codes={c:GetCode()}
 		for _,code in ipairs(codes) do
-			s.CheckCodeToken:Recreate(code)
-			if not s.CheckCodeToken:IsType(TYPE_TOKEN|TYPE_EXTRA) then
+			local typ=Duel.GetCardTypeFromCode(code)
+			if typ&(TYPE_TOKEN|TYPE_EXTRA)==0 then
 				return true
 			end
 		end
@@ -81,9 +73,4 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not tc:IsRelateToEffect(e) or not tc:IsFaceup() then return end
 	local dg=Duel.GetMatchingGroup(Card.IsCode,tc:GetControler(),LOCATION_DECK|LOCATION_HAND,0,nil,tc:GetCode())
 	Duel.Destroy(dg,REASON_EFFECT)
-end
-
-function s.createtoken(e)
-	s.CheckCodeToken=Duel.CreateToken(0,0)
-	e:Reset()
 end

--- a/official/c1248895.lua
+++ b/official/c1248895.lua
@@ -63,8 +63,9 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
-		local g=Duel.GetMatchingGroup(Card.IsCode,tc:GetControler(),LOCATION_HAND|LOCATION_DECK,0,nil,tc:GetCode())
+	if not (tc:IsRelateToEffect(e) and tc:IsFaceup()) then return end
+	local g=Duel.GetMatchingGroup(Card.IsCode,tc:GetControler(),LOCATION_HAND|LOCATION_DECK,0,nil,tc:GetCode())
+	if #g>0 then
 		Duel.Destroy(g,REASON_EFFECT)
 	end
 end

--- a/official/c1248895.lua
+++ b/official/c1248895.lua
@@ -4,6 +4,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
@@ -18,60 +19,52 @@ function s.initial_effect(c)
 	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e3)
 end
-
-function s.filter(c,e,tp)
-	if not (c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsAttackBelow(2000) and (not e or c:IsCanBeEffectTarget(e))) then return false end
-	local p=c:GetControler()
-	if p==tp then
-		return Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_DECK|LOCATION_HAND,0,1,nil,c:GetCode())
+function s.tgfilter(c,e,tp)
+	if not (c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsAttackBelow(2000) and c:IsCanBeEffectTarget(e)) then return false end
+	if c:IsControler(tp) then
+		return Duel.IsExistingMatchingCard(Card.IsCode,tp,LOCATION_HAND|LOCATION_DECK,0,1,nil,c:GetCode())
 	else
-		return Duel.GetFieldGroupCount(p,LOCATION_HAND|LOCATION_DECK,0)>0 and s.mdnamecheck(c)
+		return Duel.GetFieldGroupCount(c:GetControler(),LOCATION_HAND|LOCATION_DECK,0)>0 and s.mdnamecheck(c)
 	end
 end
 function s.mdnamecheck(c)
-	if c:IsType(TYPE_TOKEN|TYPE_EXTRA) or c:IsHasEffect(EFFECT_CHANGE_CODE) then
-		local codes={c:GetCode()}
-		for _,code in ipairs(codes) do
-			local typ=Duel.GetCardTypeFromCode(code)
-			if typ&(TYPE_TOKEN|TYPE_EXTRA)==0 then
-				return true
-			end
+	local codes={c:GetCode()}
+	for _,code in ipairs(codes) do
+		local typ=Duel.GetCardTypeFromCode(code)
+		if typ&(TYPE_TOKEN|TYPE_EXTRA)==0 then
+			return true
 		end
-		return false
 	end
-	return true
+	return false
 end
-function s.publicfilter(c,p,...)
-	return c:IsCode(...) and (c:IsPublic() or (c:IsLocation(LOCATION_DECK) and c:GetSequence()==Duel.GetFieldGroupCount(p,LOCATION_DECK,0)-1 and Duel.IsPlayerAffectedByEffect(p,EFFECT_REVERSE_DECK)))
+function s.publicfilter(c,convulsion,top_card,...)
+	return c:IsCode(...) and (c:IsPublic() or (convulsion and c==top_card))
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return eg:IsContains(chkc) and s.filter(chkc,nil,tp) end
-	if chk==0 then return eg:IsExists(s.filter,1,nil,e,tp) end
-	local tc
-	if #eg==1 then
-		Duel.SetTargetCard(eg)
-		tc=eg:GetFirst()
+	local tg=eg:Filter(s.tgfilter,nil,e,tp)
+	if chkc then return tg:IsContains(chkc) end
+	if chk==0 then return #tg>0 end
+	local tc=nil
+	if #tg==1 then
+		tc=tg:GetFirst()
 	else
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
-		local g=eg:FilterSelect(tp,s.filter,1,1,nil,e,tp)
-		Duel.SetTargetCard(g)
-		tc=g:GetFirst()
+		tc=tg:Select(tp,1,1,nil):GetFirst()
 	end
-	local p=tc:GetControler()
-	if p==tp then
-		Duel.SetOperationInfo(0,CATEGORY_DESTROY,nil,1,p,LOCATION_DECK|LOCATION_HAND)
-	else
-		local public=Duel.GetMatchingGroup(s.publicfilter,p,LOCATION_DECK|LOCATION_HAND,0,nil,p,tc:GetCode())
-		if #public>0 then
-			Duel.SetOperationInfo(0,CATEGORY_DESTROY,public,#public,p,LOCATION_DECK|LOCATION_HAND)
-		else
-			Duel.SetPossibleOperationInfo(0,CATEGORY_DESTROY,nil,1,p,LOCATION_DECK|LOCATION_HAND)
-		end
+	Duel.SetTargetCard(tc)
+	local ctrl_player=tc:GetControler()
+	local top_card=Duel.GetDecktopGroup(ctrl_player,1):GetFirst()
+	local convulsion=Duel.IsPlayerAffectedByEffect(ctrl_player,EFFECT_REVERSE_DECK)
+	local dg=Duel.GetMatchingGroup(s.publicfilter,ctrl_player,LOCATION_HAND|LOCATION_DECK,0,nil,convulsion,top_card,tc:GetCode())
+	if #dg>0 then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,dg,#dg,tp,0)
 	end
+	Duel.SetPossibleOperationInfo(0,CATEGORY_DESTROY,nil,1,ctrl_player,LOCATION_HAND|LOCATION_DECK)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if not tc:IsRelateToEffect(e) or not tc:IsFaceup() then return end
-	local dg=Duel.GetMatchingGroup(Card.IsCode,tc:GetControler(),LOCATION_DECK|LOCATION_HAND,0,nil,tc:GetCode())
-	Duel.Destroy(dg,REASON_EFFECT)
+	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		local g=Duel.GetMatchingGroup(Card.IsCode,tc:GetControler(),LOCATION_HAND|LOCATION_DECK,0,nil,tc:GetCode())
+		Duel.Destroy(g,REASON_EFFECT)
+	end
 end


### PR DESCRIPTION
The Normal Trap "Chain Destruction", which reads...
> When a monster(s) with 2000 or less ATK is Summoned: Target 1 of them; destroy all cards with that name in its controller's hand and Main Deck.
...currently has the following issues:
- At the time of resolution, if the target left the Monster Zone between the activation and resolution of "Chain Destruction", or if it is currently in face-down Defense Position, the effect of "Chain Destruction" still destroys any available card in the hand and Main Deck of the controller, even though it shouldn't be able to. (Link to the FAQ on the Konami DB, refer to the last bulleted entry: https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=4&cid=4813)
- When a Fusion, Synchro, Xyz, or Link Monster is Summoned, "Chain Destruction" should not be able to be activated, unless that monster has a name of a card that can be placed in hand/Main Deck. (Link to the translated Q&A on the YGOrganization DB: https://db.ygorganization.com/qa#13158)

The following link redirects to the bug report in the official_card_rulings_bugs channel of the ProjectIgnis Discord server, where relevant replays reproducing the bugs can be found: https://discord.com/channels/170601678658076672/184324960842416129/1231661707332423761

The first problem was fixed by invoking the Card.IsRelateToEffect and Card.IsFaceup functions at the beginning of the Operation Function.

The second problem was more complex and prompted several changes regarding activation legality:
- If the Summoned monster is controlled by the activator of "Chain Destruction", then I made it so it can be targeted only if there exists a card with its same name in the activator's hand and/or Main Deck. Therefore, a Duel.IsExistingMatchingCard call was added to the filter.
- If the Summoned monster is controlled by the opponent of the activator, then it can be targeted only if it has a name of a card that can be placed in the hand and/or Main Deck. To check this property, the script spawns a hidden Token as soon as it is allowed to once the Duel starts: while the filter is being ran, for each of the names the Summoned monster has, this Token is transformed into the card that has that original name; if the Token's card type is still TYPE_TOKEN or if it is still an Extra Deck Monster, then it means that the name is not eligible for the activation of "Chain Destruction". The check is passed as soon as 1 eligible name is found. This procedure is defined by the `s.mdnamecheck` function inside the script. This procedure is followed if the opponent Summons a Fusion, Synchro, Xyz or Link Monster, following what was stated in the Q&A: I also made it so the names are checked even if Tokens are Summoned by the opponent, and if the monster they Summon is affected by an EFFECT_CHANGE_CODE effect (to future-proof the case of Main Deck monsters taking the name of a card that cannot be found in the hand/Main Deck).

Additionally, missing Operation Info functions were added in the Target Function:
- If the targeted monster is controlled by the activator, the script invokes Duel.SetOperationInfo
- If the targeted monster is controlled by the opponent, the script invokes Duel.SetOperationInfo only if there exist public cards in the hand and/or Main Deck of the opponent (either because they are revealed in the hand, or because they are face-up in the Deck due to "Convulsion of Nature"). Otherwise, the script invokes Duel.SetPossibleOperationInfo.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
