### PR TITLE
Fix "Divination of Fate"

### DIFF
--- a/unofficial/c511000602.lua
+++ b/unofficial/c511000602.lua
@@ -11,28 +11,29 @@ function s.initial_effect(c)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 	aux.GlobalCheck(s,function()
-		s[0]=false
-		s[1]=false
 		local ge1=Effect.CreateEffect(c)
 		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		ge1:SetCode(EVENT_DAMAGE_STEP_END)
+		ge1:SetCode(EVENT_BATTLE_DESTROYED)
 		ge1:SetOperation(s.checkop)
 		Duel.RegisterEffect(ge1,0)
-		aux.AddValuesReset(function()
-			s[0]=false
-			s[1]=false
-		end)
 	end)
 end
 function s.checkop(e,tp,eg,ep,ev,re,r,rp)
-	local at=Duel.GetAttackTarget()
-	if at and at:IsRelateToBattle() and not at:IsStatus(STATUS_BATTLE_DESTROYED) then
-		s[0]=true
-		s[1]=true
+	local tc=eg:GetFirst()
+	local bc=tc:GetBattleTarget()
+	local p1=false
+	local p2=false
+	for tc in aux.Next(eg) do
+		if tc:IsPreviousLocation(LOCATION_MZONE) then
+			if bc:IsControler(tp) and tc:IsPreviousControler(1) then p1=true end
+			if bc:IsControler(1-tp) and tc:IsPreviousControler(0) then p2=true end
+		end
 	end
+	if p1 then Duel.RegisterFlagEffect(0,id,RESET_PHASE+PHASE_END,0,1) end
+	if p2 then Duel.RegisterFlagEffect(1,id,RESET_PHASE+PHASE_END,0,1) end
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return s[tp]
+	return Duel.GetFlagEffect(tp,id)==0 and Duel.GetCurrentPhase()==PHASE_MAIN2
 end
 function s.spfilter(c,e,tp)
 	return c:IsLevelBelow(4) and c:IsSetCard(0x5) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)


### PR DESCRIPTION
https://yugipedia.com/wiki/Divination_of_Fate

If you are submitting a bug fix, the pull request title should be of the form `Fix "CARD NAME"`.
In this case, replace this comment with a brief summary of your change. What did you fix?
---> I think the effect of "Divination of Fate" is wrongly interpreted

What we have right now is a Photon Wind. But the text seems to me more like the reverse of Lineage of Destruction, if that makes sense. "Activate only if a monster you control did not destroy an opponent's monster by battle during this turn's Battle Phase". The condition is that your monster hasn't destroyed an opponent's monster this turn. If you did, the card wouldn't activate. You need to pass your Battle Phase without destroying any enemy monsters by battle, move onto MP2, then you can finally activate this card

The card text doesn't have PSCT and it's impossible to know what it means for sure. But I think it would've been more specific on it's condition if it was Photon Wind V2

- [X] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [X] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).