### PR TITLE
Fix "Dimensional Allotrope Varis"

### DIFF
--- a/official/c52254878.lua
+++ b/official/c52254878.lua
@@ -26,8 +26,8 @@ end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local c=e:GetHandler()
-	local rc=c:AnnounceAnotherRace(tp)
-	local att=c:AnnounceAnotherAttribute(tp)
+	local rc=Duel.AnnounceRace(tp,1,RACE_ALL)
+	local att=c:IsDifferentRace(rc) and Duel.AnnounceAttribute(tp,1,ATTRIBUTE_ALL) or c:AnnounceAnotherAttribute(tp)
 	e:SetLabel(rc,att)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
According to the Konami FAQ (https://db.ygoresources.com/card#18173), the Ignition Effect of Varis can be activated by declaring AT LEAST 1 value (among Type and Attribute) that is different from the current corresponding value of the card itself.
> At this time, either the declared Type must be different from this card's current Type, or the declared Attribute must be different from this card's current Attribute, or both.

Currently, EDOPro forces the player to declare BOTH a different Type and a different Attribute, effectively preventing them from changing only 1 property. For instance, if Varis is a Psychic/LIGHT, the current script prevents the player from declaring those two values at all: therefore, combinations like Machine/LIGHT and Psychic/DARK cannot be declared, even though they should be allowed according to the FAQ.

The fix was implemented as follows. In the Target Function `s.target`:
- The Card.AnnounceAnotherRace function was replaced with Duel.AnnounceRace, in order to let the player declare any Monster Type
- Depending on the Monster Type that was declared, the Attribute declaration is performed either by Duel.AnnounceAttribute (if the card has a Type different from the declared one) or by Card.AnnounceAnotherAttribute (if the Type of the card exactly matches the declared one). This way, the script should prevent the player from choosing a Type/Attribute combination that exactly matches the current one of the card, but it will not prevent them from declaring a combination that only has 1 value that matches the corresponding one of the card.

Link to the bug report on Discord: https://discord.com/channels/170601678658076672/1264554677534593104

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).