### PR TITLE
Fix "Blowback Dragon"

### DIFF
--- a/official/c25551951.lua
+++ b/official/c25551951.lua
@@ -6,7 +6,7 @@ function s.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetCategory(CATEGORY_DESTROY+CATEGORY_COIN)
+	e1:SetCategory(CATEGORY_DESTROY|CATEGORY_COIN)
 	e1:SetType(EFFECT_TYPE_IGNITION)
 	e1:SetRange(LOCATION_MZONE)
 	e1:SetCountLimit(1)
@@ -21,10 +21,11 @@ function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
 	local g=Duel.SelectTarget(tp,nil,tp,0,LOCATION_ONFIELD,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,3)
+	Duel.SetPossibleOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and tc:IsControler(1-tp) then
 		if Duel.CountHeads(Duel.TossCoin(tp,3))<2 then return end
 		Duel.Destroy(tc,REASON_EFFECT)
 	end


### PR DESCRIPTION
The effect of Blowback Dragon states:
> Once per turn: You can target 1 card **your opponent controls**; toss a coin 3 times and destroy **that target** if at least 2 of the results are heads.

Since it uses the wording **that target**, the effect should do nothing at resolution if the opponent is not the controller of the targeted card anymore.

The changes to the scripts are the following:
- Added a check for the target in the operation function with Card.IsControler
- Added a call to Duel.SetPossibleOperationInfo in the target function (with CATEGORY_DESTROY)
- Minor changes to modernize the scripts (replace the + operator with the | operator where applicable)

Link to the bug report Discord forum post with replay attached: https://discord.com/channels/170601678658076672/1265776775783252079

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).

