### PR TITLE
Fix "Mementotlan Tatsunootoshigo"

### DIFF
--- a/official/c81677154.lua
+++ b/official/c81677154.lua
@@ -57,7 +57,7 @@ function s.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.rescon(lv)
 	return function(sg,e,tp,mg)
-		return sg:GetSum(Card.GetLevel)<=lv and sg:GetClassCount(Card.GetCode)==#sg
+		return sg:GetSum(Card.GetLevel)<=lv and sg:GetClassCount(Card.GetCode)==#sg,sg:GetClassCount(Card.GetCode)~=#sg
 	end
 end
 function s.tgop(e,tp,eg,ep,ev,re,r,rp)
@@ -66,7 +66,7 @@ function s.tgop(e,tp,eg,ep,ev,re,r,rp)
 	if tc and Duel.Destroy(tc,REASON_EFFECT)>0 then
 		local lv=tc:GetOriginalLevel()
 		local g=Duel.GetMatchingGroup(s.tgfilter,tp,LOCATION_DECK,0,nil,lv)
-		local sg=aux.SelectUnselectGroup(g,e,tp,1,lv,s.rescon(lv),1,tp,HINTMSG_TOGRAVE)
+		local sg=aux.SelectUnselectGroup(g,e,tp,1,lv,s.rescon(lv),1,tp,HINTMSG_TOGRAVE,s.rescon(lv))
 		if #sg>0 then
 			Duel.SendtoGrave(sg,REASON_EFFECT)
 		end


### PR DESCRIPTION
Add early termination condition to stop checking combinations when duplicate names are detected, reducing unnecessary computations.

Bug fixed: If you destroy a level 9 Mementotlan monster and then choose any Mementotlan monster, it will cause the game to stall for a very long time.

---
- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [ ] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).

**New card checklist**

- [ ] I have submitted a corresponding database entry for [BabelCDB](https://github.com/ProjectIgnis/BabelCDB/blob/master/README.md) according to its guidelines. Link to the pull request: _fill in_
- [ ] This card is not marked with a reason to not be added in the unofficial card tracker in `#card-scripting-101`.
Supervising staff member(s): _fill in_
