### PR TITLE
Fixed effects that set cards to the opponent's field

### DIFF
--- a/official/c23002292.lua
+++ b/official/c23002292.lua
@@ -4,6 +4,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--Negate the activation of a Trap Card
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_NEGATE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_CHAINING)
@@ -14,7 +15,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 	--Can be activated from the hand
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(id,2))
+	e2:SetDescription(aux.Stringid(id,1))
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetCode(EFFECT_TRAP_ACT_IN_HAND)
 	e2:SetValue(function(e,c) e:SetLabel(1) end)
@@ -22,8 +23,7 @@ function s.initial_effect(c)
 	e1:SetLabelObject(e2)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return rp~=tp and re:IsHasType(EFFECT_TYPE_ACTIVATE)
-		and re:IsTrapEffect() and Duel.IsChainNegatable(ev)
+	return rp==1-tp and re:IsTrapEffect() and re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then e:GetLabelObject():SetLabel(0) return true end
@@ -32,8 +32,8 @@ function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 		Duel.PayLPCost(tp,Duel.GetLP(tp)//2)
 	end
 end
-function s.setfilter(c)
-	return c:IsTrap() and c:IsSSetable(true)
+function s.setfilter(c,tp)
+	return c:IsTrap() and c:IsSSetable(false,1-tp)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
@@ -47,15 +47,15 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		rc:SetStatus(STATUS_ACTIVATE_DISABLED,false)
 		rc:SetStatus(STATUS_SET_TURN,false)
 		Duel.RaiseEvent(rc,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
-		local g=Duel.GetMatchingGroup(s.setfilter,tp,0,LOCATION_DECK,nil)
-		if #g>0 and Duel.GetLocationCount(1-tp,LOCATION_SZONE)>0 and Duel.SelectYesNo(1-tp,aux.Stringid(id,0)) then
+		local g=Duel.GetMatchingGroup(s.setfilter,tp,0,LOCATION_DECK,nil,tp)
+		if #g>0 and Duel.GetLocationCount(1-tp,LOCATION_SZONE)>0 and Duel.SelectYesNo(1-tp,aux.Stringid(id,2)) then
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 			local sg=g:Select(1-tp,1,1,nil)
 			Duel.SSet(1-tp,sg:GetFirst())
 		end
 	end
 	local e1=Effect.CreateEffect(e:GetHandler())
-	e1:SetDescription(aux.Stringid(id,1))
+	e1:SetDescription(aux.Stringid(id,3))
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_CLIENT_HINT)

--- a/official/c47766694.lua
+++ b/official/c47766694.lua
@@ -2,8 +2,9 @@
 --Wild Tornado
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Destroy 1 face-up card in the Spell/Trap Zone
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_DESTROY)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
@@ -11,7 +12,7 @@ function s.initial_effect(c)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
-	--Destroy
+	--Destroy 1 face-up card on the field
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,1))
 	e2:SetCategory(CATEGORY_DESTROY)
@@ -23,21 +24,19 @@ function s.initial_effect(c)
 	e2:SetOperation(s.desop)
 	c:RegisterEffect(e2)
 end
-function s.filter(c)
-	return c:IsFaceup() and c:GetSequence()<5
-end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsLocation(LOCATION_SZONE) and s.filter(chkc) and chkc~=e:GetHandler() end
-	if chk==0 then return Duel.IsExistingTarget(s.filter,tp,LOCATION_SZONE,LOCATION_SZONE,1,e:GetHandler()) end
+	local c=e:GetHandler()
+	if chkc then return chkc:IsLocation(LOCATION_SZONE) and chkc:IsFaceup() and chkc~=c end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_STZONE,LOCATION_STZONE,1,c) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
-	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_SZONE,LOCATION_SZONE,1,1,e:GetHandler())
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_STZONE,LOCATION_STZONE,1,1,c)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0 then
+	if tc:IsFaceup() and tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)>0 then
 		local dp=tc:GetControler()
-		local g=Duel.GetMatchingGroup(Card.IsSSetable,dp,LOCATION_HAND,0,nil)
+		local g=Duel.GetMatchingGroup(Card.IsSSetable,dp,LOCATION_HAND,0,nil,false,dp)
 		if #g>0 and Duel.SelectYesNo(dp,aux.Stringid(id,0)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)

--- a/official/c57314798.lua
+++ b/official/c57314798.lua
@@ -5,7 +5,7 @@ function s.initial_effect(c)
 	--Xyz Summon
 	Xyz.AddProcedure(c,s.xyzfilter,nil,2,nil,nil,nil,nil,false,s.xyzcheck)
 	c:EnableReviveLimit()
-	--Gain ATK equal to the combined Ranks x 1000
+	--Gains ATK equal to the combined Ranks of all Xyz monsters on the field x 1000
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_ATKCHANGE)
@@ -16,17 +16,17 @@ function s.initial_effect(c)
 	e1:SetTarget(s.atktg)
 	e1:SetOperation(s.atkop)
 	c:RegisterEffect(e1,false,REGISTER_FLAG_DETACH_XMAT)
-	--Destroy when destroyed and set Spell/Trap
+	--Destroy as many monsters on the field as possible and each player sets 1 Spell/Trap from the GY
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,1))
 	e2:SetCategory(CATEGORY_DESTROY)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_DESTROYED)
-	e2:SetCondition(s.descon)
+	e2:SetCondition(function(e) return e:GetHandler():IsReason(REASON_EFFECT) end)
 	e2:SetTarget(s.destg)
 	e2:SetOperation(s.desop)
 	c:RegisterEffect(e2)
-	--Special Summon itself from GY when opp attacks
+	--Special Summon this card from the GY
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(id,2))
 	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -66,11 +66,8 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESETS_STANDARD_DISABLE_PHASE_END|RESET_OPPO_TURN)
 	c:RegisterEffect(e1)
 end
-function s.descon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsReason(REASON_EFFECT)
-end
-function s.setfilter(c)
-	return c:IsSpellTrap() and c:IsSSetable()
+function s.setfilter(c,tp)
+	return c:IsSpellTrap() and c:IsSSetable(false,tp)
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
@@ -83,9 +80,9 @@ function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.Destroy(g,REASON_EFFECT)==0 then return end
 	Duel.BreakEffect()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
-	local tc1=Duel.SelectMatchingCard(tp,s.setfilter,tp,LOCATION_GRAVE,0,1,1,nil):GetFirst()
+	local tc1=Duel.SelectMatchingCard(tp,s.setfilter,tp,LOCATION_GRAVE,0,1,1,nil,tp):GetFirst()
 	Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_SET)
-	local tc2=Duel.SelectMatchingCard(1-tp,s.setfilter,1-tp,LOCATION_GRAVE,0,1,1,nil):GetFirst()
+	local tc2=Duel.SelectMatchingCard(1-tp,s.setfilter,1-tp,LOCATION_GRAVE,0,1,1,nil,1-tp):GetFirst()
 	if (tc1 and tc1:IsHasEffect(EFFECT_NECRO_VALLEY)) or (tc2 and tc2:IsHasEffect(EFFECT_NECRO_VALLEY)) then return end
 	if tc1 then
 		Duel.SSet(tp,tc1)

--- a/official/c63086455.lua
+++ b/official/c63086455.lua
@@ -20,7 +20,7 @@ function s.tgfilter(c,e)
 	return c:IsAbleToGrave() and c:IsCanBeEffectTarget(e)
 end
 function s.setfilter(c,e,tp)
-	return c:IsCanBeEffectTarget(e) and ((c:IsSpellTrap() and c:IsSSetable(true))
+	return c:IsCanBeEffectTarget(e) and ((c:IsSpellTrap() and c:IsSSetable(true,1-tp))
 		or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE,1-tp))
 end
 function s.rescon(sg,e,tp)
@@ -60,7 +60,7 @@ function s.tgop(e,tp,eg,ep,ev,re,r,rp)
 		if sc:IsMonster() and Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0
 			and Duel.SpecialSummon(sc,0,tp,1-tp,false,false,POS_FACEDOWN_DEFENSE)>0 then
 			Duel.ConfirmCards(1-tp,sc)
-		elseif sc:IsSpellTrap() and sc:IsSSetable() then
+		elseif sc:IsSpellTrap() and sc:IsSSetable(false,1-tp) then
 			Duel.SSet(tp,sc,1-tp)
 		end
 	end

--- a/official/c64659851.lua
+++ b/official/c64659851.lua
@@ -3,7 +3,7 @@
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Your opponent can Set 1 Trap from their hand or Deck
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOHAND+CATEGORY_SEARCH)
@@ -29,12 +29,12 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetPossibleOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 	Duel.SetPossibleOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
 end
-function s.setfilter(c)
-	return c:IsTrap() and c:IsSSetable(true)
+function s.setfilter(c,tp)
+	return c:IsTrap() and c:IsSSetable(false,1-tp)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local summon=false
-	local g=Duel.GetMatchingGroup(s.setfilter,tp,0,LOCATION_HAND|LOCATION_DECK,nil)
+	local g=Duel.GetMatchingGroup(s.setfilter,tp,0,LOCATION_HAND|LOCATION_DECK,nil,tp)
 	if Duel.GetLocationCount(1-tp,LOCATION_SZONE,1-tp,LOCATION_REASON_TOFIELD)>0 and #g>0 and Duel.SelectYesNo(1-tp,aux.Stringid(id,1)) then
 		Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_SET)
 		local sg=g:Select(1-tp,1,1,nil)

--- a/official/c64961254.lua
+++ b/official/c64961254.lua
@@ -49,7 +49,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetTargetParam(Duel.SelectOption(tp,DECLTYPE_MONSTER,DECLTYPE_SPELL,DECLTYPE_TRAP))
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(1-tp,0,LOCATION_DECK)<=0 return end
+	if Duel.GetFieldGroupCount(1-tp,0,LOCATION_DECK)<=0 then return end
 	Duel.DisableShuffleCheck()
 	Duel.ConfirmDecktop(1-tp,1)
 	local g=Duel.GetDecktopGroup(1-tp,1)

--- a/official/c64961254.lua
+++ b/official/c64961254.lua
@@ -11,18 +11,18 @@ function s.initial_effect(c)
 	e1:SetCountLimit(1,id,EFFECT_COUNT_CODE_OATH)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
-	--see top
-	local e3=Effect.CreateEffect(c)
-	e3:SetDescription(aux.Stringid(id,1))
-	e3:SetType(EFFECT_TYPE_IGNITION)
-	e3:SetCountLimit(1)
-	e3:SetRange(LOCATION_SZONE)
-	e3:SetTarget(s.target)
-	e3:SetOperation(s.operation)
-	c:RegisterEffect(e3)
+	--Reveal the top card of your opponent's Deck and if it was the declared type, they Set it to their field
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCountLimit(1)
+	e2:SetTarget(s.target)
+	e2:SetOperation(s.operation)
+	c:RegisterEffect(e2)
 end
 s.listed_series={SET_VALKYRIE}
-s.listed_names={91969909}
+s.listed_names={91969909} --"Goddess Urd's Verdict"
 function s.thcfilter(c)
 	return c:IsFacedown() or not c:IsSetCard(SET_VALKYRIE)
 end
@@ -34,7 +34,6 @@ function s.thfilter(c)
 	return c:IsCode(91969909) and c:IsAbleToHand()
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local g=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_DECK,0,nil)
 	if #g>0 and s.thcon(e,tp,eg,ep,ev,re,r,rp) and
 		Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
@@ -47,11 +46,10 @@ end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsPlayerCanDiscardDeck(1-tp,1) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CARDTYPE)
-	Duel.SetTargetParam(Duel.SelectOption(tp,70,71,72))
+	Duel.SetTargetParam(Duel.SelectOption(tp,DECLTYPE_MONSTER,DECLTYPE_SPELL,DECLTYPE_TRAP))
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetFieldGroupCount(1-tp,0,LOCATION_DECK)<=0
-		or not e:GetHandler():IsRelateToEffect(e)then return end
+	if Duel.GetFieldGroupCount(1-tp,0,LOCATION_DECK)<=0 return end
 	Duel.DisableShuffleCheck()
 	Duel.ConfirmDecktop(1-tp,1)
 	local g=Duel.GetDecktopGroup(1-tp,1)
@@ -62,7 +60,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 		and Duel.GetLocationCount(1-tp,LOCATION_MZONE)>0
 		and tc:IsCanBeSpecialSummoned(e,0,1-tp,false,false,POS_FACEDOWN_DEFENSE,1-tp)) then
 		Duel.SpecialSummon(tc,0,1-tp,1-tp,false,false,POS_FACEDOWN_DEFENSE)
-	elseif ((opt==1 and tc:IsSpell()) or (opt==2 and tc:IsTrap())) and tc:IsSSetable() then
+	elseif ((opt==1 and tc:IsSpell()) or (opt==2 and tc:IsTrap())) and tc:IsSSetable(false,1-tp) then
 		Duel.DisableShuffleCheck()
 		Duel.SSet(1-tp,tc)
 	else

--- a/official/c67248304.lua
+++ b/official/c67248304.lua
@@ -1,7 +1,6 @@
 --リバースポッド
 --Reverse Jar
---Logical Nonsense
---Substitute ID
+--scripted by Logical Nonsense
 local s,id=GetID()
 function s.initial_effect(c)
 	--Change as many other monsters to face-down defense
@@ -17,16 +16,15 @@ end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	local fdg=Duel.GetMatchingGroup(Card.IsCanTurnSet,tp,LOCATION_MZONE,LOCATION_MZONE,e:GetHandler())
-	local thg=Duel.GetMatchingGroup(aux.AND(Card.IsAbleToHand,aux.FaceupFilter(Card.IsType,TYPE_SPELL|TYPE_TRAP)),tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	local thg=Duel.GetMatchingGroup(aux.AND(Card.IsAbleToHand,aux.FaceupFilter(Card.IsSpellTrap)),tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_POSITION,fdg,#fdg,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,thg,#thg,0,0)
 end
-	--Change as many other monsters to face-down defense
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsCanTurnSet,tp,LOCATION_MZONE,LOCATION_MZONE,e:GetHandler())
 	if #g==0 then return end
 	if Duel.ChangePosition(g,POS_FACEDOWN_DEFENSE)==0 then return end
-	local g2=Duel.GetMatchingGroup(aux.AND(Card.IsAbleToHand,aux.FaceupFilter(Card.IsType,TYPE_SPELL|TYPE_TRAP)),tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	local g2=Duel.GetMatchingGroup(aux.AND(Card.IsAbleToHand,aux.FaceupFilter(Card.IsSpellTrap)),tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
 	if #g2==0 then return end
 	Duel.BreakEffect()
 	if Duel.SendtoHand(g2,nil,REASON_EFFECT)==0 then return end
@@ -38,7 +36,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local turn_p=Duel.GetTurnPlayer()
 	local step=turn_p==0 and 1 or -1
 	for p=turn_p,1-turn_p,step do
-		local setg=Duel.GetMatchingGroup(Card.IsSSetable,p,LOCATION_HAND,0,nil)
+		local setg=Duel.GetMatchingGroup(Card.IsSSetable,p,LOCATION_HAND,0,nil,false,p)
 		local setmax_ct=0
 		if p==tp then
 			setmax_ct=math.min(#setg,ct1)
@@ -55,7 +53,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.rescon(sg,e,tp,mg)
-	return sg:FilterCount(Card.IsSSetable,nil)==#sg
+	return sg:FilterCount(Card.IsSSetable,nil,false,tp)==#sg
 		and sg:FilterCount(aux.NOT(Card.IsType),nil,TYPE_FIELD)<=Duel.GetLocationCount(tp,LOCATION_SZONE)
 		and sg:FilterCount(Card.IsType,nil,TYPE_FIELD)<=1
 end

--- a/unofficial/c511000583.lua
+++ b/unofficial/c511000583.lua
@@ -1,32 +1,30 @@
+--トラップ・リクエスト
 --Trap Request
 local s,id=GetID()
 function s.initial_effect(c)
-	--activate
+	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	c:RegisterEffect(e1)
-	--set
+	--Set 1 Trap Card from your opponent's Deck to their Spell/Trap Zone
 	local e2=Effect.CreateEffect(c)
 	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
 	e2:SetCode(EVENT_PHASE+PHASE_STANDBY)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCountLimit(1)
-	e2:SetCondition(s.condition)
+	e2:SetCondition(function(e,tp) return Duel.IsTurnPlayer(tp) end)
 	e2:SetOperation(s.operation)
 	c:RegisterEffect(e2)
 end
-function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return tp==Duel.GetTurnPlayer()
-end
-function s.filter(c)
-	return c:IsTrap() and c:IsSSetable()
+function s.filter(c,tp)
+	return c:IsTrap() and c:IsSSetable(1-tp)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if Duel.GetLocationCount(1-tp,LOCATION_SZONE)<=0 then return end
-	local sg=Duel.GetMatchingGroup(s.filter,tp,0,LOCATION_DECK,nil)
+	local sg=Duel.GetMatchingGroup(s.filter,tp,0,LOCATION_DECK,nil,tp)
 	Duel.ConfirmCards(tp,sg)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 	local g=sg:Select(tp,1,1,nil)
@@ -37,14 +35,14 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CANNOT_TRIGGER)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e1:SetReset(RESET_EVENT|RESETS_STANDARD)
 		e1:SetValue(1)
 		tc:RegisterEffect(e1)
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
 		e2:SetCode(EVENT_LEAVE_FIELD_P)
 		e2:SetOperation(s.regop)
-		e2:SetReset(RESET_EVENT+RESETS_REDIRECT)
+		e2:SetReset(RESET_EVENT|RESETS_REDIRECT)
 		tc:RegisterEffect(e2,true)
 	end
 end


### PR DESCRIPTION
The IsSSetable function now has the `target player` parameter exposed as is third parameter. Defaulting to the reason player caused problems when the player using the effect did not have a zone available, even if the player that would receive the card had one.