### PR TITLE
Fix Catapult Turtle (Pre-Errata)

### DIFF
--- a/pre-errata/c511000228.lua
+++ b/pre-errata/c511000228.lua
@@ -14,12 +14,9 @@ function s.initial_effect(c)
 	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
 end
-function s.cfilter(c)
-	return c:GetAttack()>0
-end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroupCost(tp,s.cfilter,1,false,nil,nil) end
-	local sg=Duel.SelectReleaseGroupCost(tp,s.cfilter,1,1,false,nil,nil)
+	if chk==0 then return Duel.CheckReleaseGroupCost(tp,nil,1,false,nil,nil) end
+	local sg=Duel.SelectReleaseGroupCost(tp,nil,1,1,false,nil,nil)
 	e:SetLabel(sg:GetFirst():GetAttack()/2)
 	Duel.Release(sg,REASON_COST)
 end


### PR DESCRIPTION
A change was made in https://github.com/ProjectIgnis/CardScripts/commit/354bf7d0dabe4833ba95838199f38772d87ec0e0 that no longer allowed this card to tribute monsters with 0 ATK for its effect, but cards of this nature were able to during that era for this type of effect.

https://ygorganization.com/ocg-011515-rulings/
https://ygorganization.com/ocg-02-08-21-rulings-update/

The 2015 article mentions a ruling for Castle Gate where you could tribute Chimeratech Fortress Dragon which has 0 original ATK, but no damage is inflicted. The 2021 article mentions the change that you can no longer tribute Chimeratech Fortress Dragon, which is in line with what's currently on the database for Castle Gate.

https://yugioh-wiki.net/index.php?%BA%DB%C4%EA%CA%D1%B9%B9#Tribute

The japanese wiki also mentions how you used to be able to tribute monsters with 0 or ? ATK for the cost of burn/healing effects, highlighting Castle Gate and other similar cards all receiving ruling changes around the same time.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
