### PR TITLE
Fix "Number 45: Crumble Logos the Prophet of Demolition"

### DIFF
--- a/official/c29208536.lua
+++ b/official/c29208536.lua
@@ -30,16 +30,17 @@ function s.initial_effect(c)
 end
 s.xyz_number=45
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return chkc:IsOnField() and chkc:IsFaceup() and chkc~=e:GetHandler() end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
+	local c=e:GetHandler()
+	if chkc then return chkc:IsOnField() and chkc:IsNegatable() and chkc~=c end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsNegatable,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,c) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())
+	local g=Duel.SelectTarget(tp,Card.IsNegatable,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,c)
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,g,1,0,0)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) and c:IsFaceup() and tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
@@ -47,6 +48,14 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT|RESETS_STANDARD)
 		e1:SetCondition(s.disablecon)
 		tc:RegisterEffect(e1)
+		if tc:IsType(TYPE_TRAPMONSTER) then
+			local e2=Effect.CreateEffect(c)
+			e2:SetType(EFFECT_TYPE_SINGLE)
+			e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e2:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+			e2:SetReset(RESET_EVENT|RESETS_STANDARD)
+			tc:RegisterEffect(e2)
+		end
 	end
 end
 function s.disablecon(e)


### PR DESCRIPTION
Made the following changes to the script:
- Added registration of EFFECT_DISABLE_TRAPMONSTER effect to the target ---> Trap Monsters (that were still treated as Traps) in the Monster Zone did not return to the Spell & Trap Zone after their effects were negated by Logos.
- Changed Card.IsFaceup with Card.IsNegatable for the target selection ---> Logos' effect could be activated by targeting a card whose effects had already been negated. The latter constitutes an invalid target according to the cited ruling (https://db.ygoresources.com/qa#19306)
- Added a Card.IsFaceup check for the handler at resolution ---> If Logos' became face-down at the time of the resolution of its effect, the negation would still go through. This should not happen according to https://db.ygoresources.com/qa#7034

I could not find a reference for whether a Trap Monster (that returned to the Spell & Trap Zone after being negated by Logos) keeps being "targeted" by it even while in the backrow, so I did not change anything in that regard and kept the Card.SetCardTarget approach, which makes Logos lose the target once it is moved from the Monster Zone to the Spell & Trap Zone.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [ ] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
