### PR TITLE
Fix Option Hunter

### DIFF
--- a/official/c33248692.lua
+++ b/official/c33248692.lua
@@ -2,8 +2,9 @@
 --Option Hunter
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Gain Life Points equal to the original ATK of the destroyed monster
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_RECOVER)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -15,14 +16,14 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.filter(c,tp)
-	return c:IsPreviousControler(tp) and c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE)
+	return c:IsPreviousControler(tp) and c:IsLocation(LOCATION_GRAVE) and c:IsMonster() and c:IsReason(REASON_BATTLE)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp,chk)
 	return eg:IsExists(s.filter,1,nil,tp)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	local rec=eg:Filter(s.filter,nil,tp):GetFirst():GetBaseAttack()
+	local rec=eg:Filter(s.filter,nil,tp):GetSum(Card.GetBaseAttack)
 	if rec<0 then rec=0 end
 	Duel.SetTargetPlayer(tp)
 	Duel.SetTargetParam(rec)


### PR DESCRIPTION
The destroyed monster must also be a monster in the graveyard for this card to be usable (trap monsters for example shouldn't count). Made it so that if 2 monsters the player controlled were destroyed in the battle, they will gain lp to their combined ATK.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
