### PR TITLE
Fix Catapult Turtle

### DIFF
--- a/official/c95727991.lua
+++ b/official/c95727991.lua
@@ -15,12 +15,12 @@ function s.initial_effect(c)
 	e1:SetOperation(s.operation)
 	c:RegisterEffect(e1)
 end
-function s.cfilter(c)
-	return c:GetAttack()>0
+function s.cfilter(c,tp)
+	return c:GetAttack()>0 and (c:IsControler(tp) or c:IsFaceup())
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroupCost(tp,s.cfilter,1,false,nil,nil) end
-	local sg=Duel.SelectReleaseGroupCost(tp,s.cfilter,1,1,false,nil,nil)
+	if chk==0 then return Duel.CheckReleaseGroupCost(tp,s.cfilter,1,false,nil,nil,tp) end
+	local sg=Duel.SelectReleaseGroupCost(tp,s.cfilter,1,1,false,nil,nil,tp)
 	e:SetLabel(sg:GetFirst():GetAttack()/2)
 	Duel.Release(sg,REASON_COST)
 end


### PR DESCRIPTION
Made it so that in the event the player is able to tribute their opponent's monsters they cannot tribute their set monsters since it's not verifiable if they are legal tributes.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
