### PR TITLE
Fix Shadow Toon (Anime)

### DIFF
--- a/unofficial/c511000549.lua
+++ b/unofficial/c511000549.lua
@@ -4,6 +4,7 @@ local s,id=GetID()
 function s.initial_effect(c)
 	--Inflict damage to your opponent equal to that monster's ATK
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_DAMAGE)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)


### PR DESCRIPTION
Should not be able to target a monster with 0 ATK, added missing Damage SetCategory and damage amount to the SetOperationInfo

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).
