### PR TITLE
Fix Cyber Jar

### DIFF
--- a/goat/c504700187.lua
+++ b/goat/c504700187.lua
@@ -1,6 +1,6 @@
 --サイバーポッド
---Cyber Jar
---Scripted by edo9300
+--Cyber Jar (GOAT)
+--The first player gets to see the second player's cards as well before deciding how to summon.
 local s,id=GetID()
 function s.initial_effect(c)
 	--flip
@@ -56,8 +56,8 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local tohand,tograve=nonsummonable1:Merge(nonsummonable2):Split(Card.IsAbleToHand,nil)
 	Duel.DisableShuffleCheck()
 	Duel.ConfirmDecktop(p,5)
-	summon(summonable1,e,p,tograve,ft1)
 	Duel.ConfirmDecktop(1-p,5)
+	summon(summonable1,e,p,tograve,ft1)
 	summon(summonable2,e,1-p,tograve,ft2)
 	Duel.SpecialSummonComplete()
 	if #tohand>0 then


### PR DESCRIPTION
<!--
Hello, thanks for submitting a pull request! Please provide enough information so we can review it.

If you are submitting an addition to the unofficial script project, the pull request title should be
of the form `Add "CARD NAME"`. Replace this comment with a Yugipedia link.

If you are submitting a bug fix, the pull request title should be of the form `Fix "CARD NAME"`.
In this case, replace this comment with a brief summary of your change. What did you fix?
--->

This makes it so with Cyber Jar the second player also reveals the top 5 cards before the first player deciding how to summon the monsters, rather than the first player not having any knowledge of the second player's cards before deciding how to summon them.

Closes #1231 

#### Video

Here is a video demonstrating that the change I made results in the expected results: 
https://www.dropbox.com/scl/fi/0kdv8j524h8xl3hq5nsuv/2025-09-11-20-17-50-Cyber-Jar-fix.mp4?rlkey=nnyrje0kbkaehndkagfnaipn3&dl=0

#### Sources:

GOAT format: https://www.goatformat.com/rulings1.html
<img width="1066" height="341" alt="image" src="https://github.com/user-attachments/assets/1bc9397d-2405-4a16-a2c0-7f6f4d3f9057" />

Latest TCG text: https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=4913&request_locale=en
Latest OCG text: https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=2&cid=4913&request_locale=ja
Oldest OCG text can be found in #1231

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).