### PR TITLE
Fix "Big Return"

### DIFF
--- a/unofficial/c511000699.lua
+++ b/unofficial/c511000699.lua
@@ -1,7 +1,7 @@
 --Big Return
 local s,id=GetID()
 function s.initial_effect(c)
-	--Activate
+	--Allow a card's once-per-turn effects to be activated again
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
@@ -12,12 +12,12 @@ function s.initial_effect(c)
 	aux.GlobalCheck(s,function()
 		s[0]={}
 		local ge1=Effect.CreateEffect(c)
-		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetType(EFFECT_TYPE_FIELD|EFFECT_TYPE_CONTINUOUS)
 		ge1:SetCode(EVENT_CHAINING)
 		ge1:SetOperation(s.checkop)
 		Duel.RegisterEffect(ge1,0)
 		local ge2=Effect.CreateEffect(c)
-		ge2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge2:SetType(EFFECT_TYPE_FIELD|EFFECT_TYPE_CONTINUOUS)
 		ge2:SetCode(EVENT_ADJUST)
 		ge2:SetCountLimit(1)
 		ge2:SetOperation(s.clear)
@@ -31,26 +31,29 @@ function s.checkop(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	if re:IsHasProperty(EFFECT_FLAG_NO_TURN_RESET) then return end
 	local _,ctmax,_,ctflag=re:GetCountLimit()
-	if ctflag&(EFFECT_COUNT_CODE_OATH+EFFECT_COUNT_CODE_DUEL)>0 or ctmax~=1 then return end
+	local excluded=EFFECT_COUNT_CODE_OATH|EFFECT_COUNT_CODE_DUEL|EFFECT_COUNT_CODE_CHAIN
+	if ctmax~=1 or (ctflag&excluded)~=0 then return end
 	if rc:GetFlagEffect(id)==0 then
 		s[0][rc]={}
-		rc:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,0)
+		rc:RegisterFlagEffect(id,RESET_EVENT|RESETS_STANDARD|RESET_PHASE|PHASE_END,0,0)
 	end
 	for _,te in ipairs(s[0][rc]) do
 		if te==re then return end
 	end
 	table.insert(s[0][rc],re)
 end
+function s.canrestore(te,tp)
+	if te:IsDeleted() or te:CheckCountLimit(tp) then return false end
+	for _,eff in ipairs({Duel.GetPlayerEffect(tp,EFFECT_CANNOT_ACTIVATE)}) do
+		local value=eff:GetValue()
+		if type(value)~="function" or value(eff,te,tp) then return false end
+	end
+	return true
+end
 function s.filter(c,tp)
 	if c:GetFlagEffect(id)==0 or c:IsHasEffect(EFFECT_CANNOT_TRIGGER) then return false end
-	local effs={Duel.GetPlayerEffect(tp,EFFECT_CANNOT_ACTIVATE)}
 	for _,te in ipairs(s[0][c]) do
-		for _,eff in ipairs(effs) do
-			if type(eff:GetValue())=='function' then
-				if eff:GetValue()(eff,te,tp) then return false end
-			else return false end
-		end
-		return true
+		if s.canrestore(te,tp) then return true end
 	end
 	return false
 end
@@ -64,8 +67,14 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) and tc:GetFlagEffect(id)>0 then
 		for _,te in ipairs(s[0][tc]) do
-			local _,ctmax,ctcode,ctflag,hopt=te:GetCountLimit()
-			te:SetCountLimit(ctmax,{ctcode,hopt},ctflag)
+			if not te:IsDeleted() and not te:CheckCountLimit(tp) then
+				local _,ctmax,ctcode,ctflag=te:GetCountLimit()
+				if ctcode~=0 or ctflag~=0 then
+					te:RestoreCountLimit(tp)
+				else
+					te:SetCountLimit(ctmax)
+				end
+			end
 		end
 	end
 end


### PR DESCRIPTION
Big Return currently tries to restore used once-per-turn effects by calling `SetCountLimit` with their existing count code and flags. This resets uncoded soft once-per-turn effects, but it leaves the core's per-player and per-card count maps consumed, so hard once-per-turn and `EFFECT_COUNT_CODE_SINGLE` effects remain unavailable.

This change:
- restores coded count limits through `Effect.RestoreCountLimit` and uncoded limits through `Effect.SetCountLimit`
- excludes OATH, DUEL, and CHAIN count limits
- skips deleted and already-available effects
- checks every tracked effect when determining whether a card is a valid target
- modernizes the touched bitset operations

Verified with Project Ignis ScriptChecker v1.5 using the current `ProjectIgnis/bin` ocgcore. Targeted regression checks covered uncoded OPT, coded HOPT, and `EFFECT_COUNT_CODE_SINGLE` restoration.

- [x] I am following the [contributing guidelines](https://github.com/ProjectIgnis/CardScripts/blob/master/CONTRIBUTING.md).
- [x] I am making the [changes to modernize the scripts](https://github.com/ProjectIgnis/CardScripts/blob/master/MODERNIZING.md).